### PR TITLE
Avoid built-in function name shadowing

### DIFF
--- a/demo/Cost-penalized custom objective.ipynb
+++ b/demo/Cost-penalized custom objective.ipynb
@@ -232,7 +232,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for iter in range(3):\n",
+    "for i in range(3):\n",
     "    campaign.fit()\n",
     "    X_suggest, eval_suggest = campaign.suggest(m_batch=3)\n",
     "    y_iter = pd.DataFrame(simulator.simulate(X_suggest))\n",

--- a/demo/Simple single objective.ipynb
+++ b/demo/Simple single objective.ipynb
@@ -190,7 +190,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for iter in range(3):\n",
+    "for i in range(3):\n",
     "    campaign.fit()\n",
     "    X_suggest, eval_suggest = campaign.suggest(m_batch=3)\n",
     "    y_iter = pd.DataFrame(simulator.simulate(X_suggest))\n",


### PR DESCRIPTION
The variable named 'iter' in demos was shadowing the built-in function 'iter()'.

```python
for iter in range(3):
    campaign.fit()
    X_suggest, eval_suggest = campaign.suggest(m_batch=3)
    y_iter = pd.DataFrame(simulator.simulate(X_suggest))
    Z_iter = pd.concat([X_suggest, y_iter, eval_suggest], axis=1)
    campaign.add_data(Z_iter)
```

This caused unexpected behavior in the code. For example, after the loop, `next(iter([None]))` will throw an error of `TypeError: 'int' object is not callable`.

This variable has been renamed to `i` to avoid such problems.