### PR TITLE
Improve random state management

### DIFF
--- a/obsidian/__init__.py
+++ b/obsidian/__init__.py
@@ -1,11 +1,13 @@
 """obsidian: Automated experiment design and black-box optimization"""
-__version__ = '0.8.6'
+
+__version__ = "0.8.6"
 
 # Import key objects
 from obsidian.campaign import Campaign
 from obsidian.optimizer import BayesianOptimizer
 from obsidian.surrogates import SurrogateBoTorch
 from obsidian.parameters import ParamSpace, Target
+from obsidian.rng import get_global_rng, reset_global_rng, USE_OLD_RNG_CONTROL, is_global_rng_initialized
 
 # Ensure that other subpackages are imported properly for documentation
 from obsidian.objectives import Objective

--- a/obsidian/__init__.py
+++ b/obsidian/__init__.py
@@ -7,7 +7,7 @@ from obsidian.campaign import Campaign
 from obsidian.optimizer import BayesianOptimizer
 from obsidian.surrogates import SurrogateBoTorch
 from obsidian.parameters import ParamSpace, Target
-from obsidian.rng import get_global_rng, reset_global_rng, USE_OLD_RNG_CONTROL, is_global_rng_initialized
+from obsidian.rng import create_rng_manager, USE_OLD_RNG_CONTROL
 
 # Ensure that other subpackages are imported properly for documentation
 from obsidian.objectives import Objective

--- a/obsidian/__init__.py
+++ b/obsidian/__init__.py
@@ -16,3 +16,4 @@ import obsidian.constraints as constraints
 import obsidian.exceptions as exceptions
 import obsidian.acquisition as acquisition
 import obsidian.plotting as plotting
+import obsidian.rng as rng

--- a/obsidian/campaign/campaign.py
+++ b/obsidian/campaign/campaign.py
@@ -59,6 +59,7 @@ class Campaign():
             optimizer_seed = seed
             designer_seed = seed
             torch_rng = None
+            warnings.warn("Using old RNG control. This is deprecated.", UserWarning)
         else:
             if rng is None:
                 self.rng = obsidian.create_rng_manager(seed)
@@ -75,7 +76,7 @@ class Campaign():
                         "Both `rng` and `seed` were provided. The seed parameter will be ignored "
                         "in favor of the seed from `rng`.", UserWarning
                     )
-                seed = self.rng.seed
+            seed = self.rng.seed
 
             torch_rng = self.rng.torch_rng
             optimizer_seed = seed
@@ -497,19 +498,32 @@ class Campaign():
 
         # Restore RNG state if saved
         rng = None
+        seed=obj_dict['seed']
         if 'rng_state' in obj_dict and obj_dict['rng_state'] is not None:
             rng = RNGManager.load_state(obj_dict['rng_state'])
+        else:
+            msg = "Loading a legacy campaign save.\nA new RNG manager object will be created to control randomness.\n"
+            if seed is None:
+                msg += "A random seed will be assigned due to seed is none."
+            else:
+                msg += f"Seed {seed} will be used to initialize the new RNG manager."
+            msg += "\nNote that due to the differences in random states by design, campaign results will be different.\nTo fully recover legacy behavior, set `obsidian.USE_OLD_RNG_CONTROL = True` before loading."
+            warnings.warn(msg, UserWarning)
 
         new_campaign = cls(X_space=ParamSpace.load_state(obj_dict['X_space']),
                            target=[Target.load_state(t_dict) for t_dict in obj_dict['target']],
                            optimizer=BayesianOptimizer.load_state(obj_dict['optimizer']),
                            objective=new_objective,
-                           seed=obj_dict['seed'],
+                           seed=seed,
                            rng=rng)
         new_campaign.data = pd.DataFrame(obj_dict['data'])
         new_campaign.data.index = new_campaign.data.index.astype('int')
-        
+
         new_campaign.iter = new_campaign.data['Iteration'].astype('int').max()
+
+        # Restore owns_rng flag (gets overwritten during __init__ when rng is passed)
+        if 'owns_rng' in obj_dict:
+            new_campaign._owns_rng = obj_dict['owns_rng']
 
         if 'output_constraints' in obj_dict:
             for const_dict in obj_dict['output_constraints']:

--- a/obsidian/campaign/campaign.py
+++ b/obsidian/campaign/campaign.py
@@ -7,6 +7,7 @@ from obsidian.objectives import Objective, Objective_Sequence, obj_class_dict
 from obsidian.constraints import Output_Constraint, const_class_dict
 from obsidian.exceptions import IncompatibleObjectiveError
 from obsidian.utils import tensordict_to_dict
+from obsidian.rng import GlobalRNG
 import obsidian
 
 import pandas as pd
@@ -49,25 +50,28 @@ class Campaign():
                  designer: ExpDesigner | None = None,
                  objective: Objective | None = None,
                  seed: int | None = None,
-                 unique_seeds: bool = False
+                 global_rng: GlobalRNG | None = None
                  ):
         
         self.set_X_space(X_space)
         self.data = pd.DataFrame()
-        
-        print("Primary seed", seed)
-        if unique_seeds:
-            if seed is not None:
-                self.primary_rng = torch.Generator().manual_seed(seed)
-            else:
-                self.primary_rng = torch.Generator()
-            optimizer_seed, designer_seed = map(int, torch.randint(0, 1_000_000, (2,), generator=self.primary_rng))
+        if obsidian.USE_OLD_RNG_CONTROL:
+            optimizer_seed = seed
+            designer_seed = seed
+            torch_rng = None
         else:
-            optimizer_seed, designer_seed = seed, seed
+            if not global_rng:
+                global_rng = obsidian.get_global_rng(seed)
+            # optimizer_seed = global_rng.np_rng
+            # designer_seed = global_rng.np_rng
+            optimizer_seed = seed
+            designer_seed = seed
+            torch_rng = global_rng.torch_rng
+            self.global_rng = global_rng
         optimizer = BayesianOptimizer(X_space, seed=optimizer_seed) if optimizer is None else optimizer
         self.set_optimizer(optimizer)
 
-        designer = ExpDesigner(X_space, seed=designer_seed) if designer is None else designer
+        designer = ExpDesigner(X_space, seed=designer_seed, torch_rng=torch_rng) if designer is None else designer
         self.set_designer(designer)
         
         self.set_target(target)
@@ -295,8 +299,8 @@ class Campaign():
         Maps ExpDesigner.initialize method
         """
         return self.designer.initialize(**design_kwargs)
-    
-    def fit(self):
+
+    def fit(self, fit_options: dict = {}):
         """
         Maps Optimizer.fit method
 
@@ -307,7 +311,7 @@ class Campaign():
         if self.m_exp <= 0:
             raise ValueError('Must register data before fitting')
 
-        self.optimizer.fit(self.data, target=self.target)
+        self.optimizer.fit(self.data, target=self.target, fit_options=fit_options)
 
     def suggest(self, **optim_kwargs):
         """

--- a/obsidian/campaign/campaign.py
+++ b/obsidian/campaign/campaign.py
@@ -7,7 +7,7 @@ from obsidian.objectives import Objective, Objective_Sequence, obj_class_dict
 from obsidian.constraints import Output_Constraint, const_class_dict
 from obsidian.exceptions import IncompatibleObjectiveError
 from obsidian.utils import tensordict_to_dict
-from obsidian.rng import GlobalRNG
+from obsidian.rng import RNGManager
 import obsidian
 
 import pandas as pd
@@ -50,9 +50,9 @@ class Campaign():
                  designer: ExpDesigner | None = None,
                  objective: Objective | None = None,
                  seed: int | None = None,
-                 global_rng: GlobalRNG | None = None
+                 rng: RNGManager | None = None
                  ):
-        
+
         self.set_X_space(X_space)
         self.data = pd.DataFrame()
         if obsidian.USE_OLD_RNG_CONTROL:
@@ -60,18 +60,42 @@ class Campaign():
             designer_seed = seed
             torch_rng = None
         else:
-            if not global_rng:
-                global_rng = obsidian.get_global_rng(seed)
-            # optimizer_seed = global_rng.np_rng
-            # designer_seed = global_rng.np_rng
+            if rng is None:
+                self.rng = obsidian.create_rng_manager(seed)
+                self._owns_rng = True
+            else:
+                # User provided explicit RNG to share
+                self.rng = rng
+                self._owns_rng = False
+                print(
+                    "Campaign is using a shared RNGManager instance. Reproducibility will depend how other objects consume from this RNG."
+                )
+                if seed is not None:
+                    warnings.warn(
+                        "Both `rng` and `seed` were provided. The seed parameter will be ignored "
+                        "in favor of the seed from `rng`.", UserWarning
+                    )
+                seed = self.rng.seed
+
+            torch_rng = self.rng.torch_rng
             optimizer_seed = seed
             designer_seed = seed
-            torch_rng = global_rng.torch_rng
-            self.global_rng = global_rng
-        optimizer = BayesianOptimizer(X_space, seed=optimizer_seed) if optimizer is None else optimizer
+
+        if not optimizer:
+            optimizer = BayesianOptimizer(
+                X_space,
+                rng=self.rng if not obsidian.USE_OLD_RNG_CONTROL else None,
+                seed=optimizer_seed
+            )
         self.set_optimizer(optimizer)
 
-        designer = ExpDesigner(X_space, seed=designer_seed, torch_rng=torch_rng) if designer is None else designer
+        if not designer:
+            designer = ExpDesigner(
+                X_space,
+                seed=designer_seed,
+                torch_rng=torch_rng,
+                np_rng=self.rng.np_rng if not obsidian.USE_OLD_RNG_CONTROL else None
+            )
         self.set_designer(designer)
         
         self.set_target(target)
@@ -433,6 +457,14 @@ class Campaign():
             obj_dict['objective'] = self.objective.save_state()
         obj_dict['seed'] = self.seed
 
+        # Save RNG state for reproducibility
+        if hasattr(self, 'rng'):
+            obj_dict['rng_state'] = self.rng.save_state()
+            obj_dict['owns_rng'] = getattr(self, '_owns_rng', False)
+        else:
+            obj_dict['rng_state'] = None
+            obj_dict['owns_rng'] = False
+
         if getattr(self, 'output_constraints', None):
             obj_dict['output_constraints'] = [{'class': const.__class__.__name__,
                                                'state': tensordict_to_dict(const.state_dict())}
@@ -462,12 +494,18 @@ class Campaign():
                 new_objective = obj_class.load_state(obj_dict['objective'])
         else:
             new_objective = None
-        
+
+        # Restore RNG state if saved
+        rng = None
+        if 'rng_state' in obj_dict and obj_dict['rng_state'] is not None:
+            rng = RNGManager.load_state(obj_dict['rng_state'])
+
         new_campaign = cls(X_space=ParamSpace.load_state(obj_dict['X_space']),
                            target=[Target.load_state(t_dict) for t_dict in obj_dict['target']],
                            optimizer=BayesianOptimizer.load_state(obj_dict['optimizer']),
                            objective=new_objective,
-                           seed=obj_dict['seed'])
+                           seed=obj_dict['seed'],
+                           rng=rng)
         new_campaign.data = pd.DataFrame(obj_dict['data'])
         new_campaign.data.index = new_campaign.data.index.astype('int')
         

--- a/obsidian/campaign/campaign.py
+++ b/obsidian/campaign/campaign.py
@@ -48,15 +48,26 @@ class Campaign():
                  optimizer: Optimizer | None = None,
                  designer: ExpDesigner | None = None,
                  objective: Objective | None = None,
-                 seed: int | None = None):
+                 seed: int | None = None,
+                 unique_seeds: bool = False
+                 ):
         
         self.set_X_space(X_space)
         self.data = pd.DataFrame()
         
-        optimizer = BayesianOptimizer(X_space, seed=seed) if optimizer is None else optimizer
+        print("Primary seed", seed)
+        if unique_seeds:
+            if seed is not None:
+                self.primary_rng = torch.Generator().manual_seed(seed)
+            else:
+                self.primary_rng = torch.Generator()
+            optimizer_seed, designer_seed = map(int, torch.randint(0, 1_000_000, (2,), generator=self.primary_rng))
+        else:
+            optimizer_seed, designer_seed = seed, seed
+        optimizer = BayesianOptimizer(X_space, seed=optimizer_seed) if optimizer is None else optimizer
         self.set_optimizer(optimizer)
 
-        designer = ExpDesigner(X_space, seed=seed) if designer is None else designer
+        designer = ExpDesigner(X_space, seed=designer_seed) if designer is None else designer
         self.set_designer(designer)
         
         self.set_target(target)

--- a/obsidian/campaign/explainer.py
+++ b/obsidian/campaign/explainer.py
@@ -1,8 +1,10 @@
 """Explainer Class: Surrogate Model Interpretation Methods"""
 
+import obsidian
 from obsidian.parameters import Param_Continuous, ParamSpace
 from obsidian.optimizer import Optimizer
 from obsidian.exceptions import UnfitError
+from obsidian.rng import get_new_seed, with_tmp_seed
 
 import shap
 from shap import KernelExplainer, Explanation
@@ -13,6 +15,7 @@ import pandas as pd
 import torch
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
+from contextlib import nullcontext
 
 
 class Explainer():
@@ -102,15 +105,32 @@ class Explainer():
             y_pred = self.optimizer.predict(X, return_f_inv=True)
             mu = y_pred[y_name+' (pred)'].values
             return mu
-        
+
+
         self.shap['pred_func'] = pred_func
         self.shap['explainer'] = KernelExplainer(pred_func,  X_ref)
-        self.shap['X_sample'] = self.X_space.unit_demap(
-            pd.DataFrame(torch.rand(size=(n, self.X_space.n_dim)).numpy(),
-                         columns=X_ref.columns)
+        if obsidian.USE_OLD_RNG_CONTROL:
+            torch_rng = None
+            # dummy context manager
+            ctx_mgr = nullcontext()
+        else:
+            torch_rng = getattr(self.optimizer, "torch_rng", None)
+            # temporarily override global random states
+            tmp_seed: int = get_new_seed(1, torch_rng) # type: ignore
+            ctx_mgr = with_tmp_seed(tmp_seed)
+
+        self.shap["X_sample"] = self.X_space.unit_demap(
+            pd.DataFrame(
+                torch.rand(size=(n, self.X_space.n_dim), generator=torch_rng).numpy(),
+                columns=X_ref.columns,
             )
-        self.shap['values'] = self.shap['explainer'].shap_values(self.shap['X_sample'],
-                                                                 seed=seed, l1_reg='aic')
+        )
+        with ctx_mgr:
+            self.shap["values"] = self.shap["explainer"].shap_values(
+                self.shap["X_sample"],
+                seed=seed,
+                l1_reg="aic",
+            )
         self.shap['explanation'] = Explanation(self.shap['values'], feature_names=X_ref.columns)
 
         return

--- a/obsidian/experiment/benchmark/optithon.py
+++ b/obsidian/experiment/benchmark/optithon.py
@@ -5,6 +5,7 @@ Simulation functions used for an optimization hackathon (OptiThon) in March 2024
 import numpy as np
 import pandas as pd
 from scipy.special import gamma
+from numpy.random import Generator
 
 
 def Vm_func(X):
@@ -61,7 +62,7 @@ def response_2(X):
     return E_curve
 
 
-def OT_simulator(X, addNoise=False):
+def OT_simulator(X, addNoise=False, generator=None):
     if isinstance(X, pd.DataFrame):
         X = X.to_numpy()
     if isinstance(X, np.ndarray) and X.ndim == 1:
@@ -88,7 +89,10 @@ def OT_simulator(X, addNoise=False):
     # Note: The overall problem is slightly heteroskedastic
     if addNoise:
         sd = 0.01+0.02*X6
-        rel_error = np.random.normal(loc=1, scale=sd, size=y.shape[0])
+        if isinstance(generator, Generator):
+            rel_error = generator.normal(loc=1, scale=sd, size=y.shape[0])
+        else:
+            rel_error = np.random.normal(loc=1, scale=sd, size=y.shape[0])
         y *= rel_error
     
     return y

--- a/obsidian/experiment/benchmark/optithon.py
+++ b/obsidian/experiment/benchmark/optithon.py
@@ -68,13 +68,15 @@ def OT_simulator(X, addNoise=False, generator=None):
     if isinstance(X, np.ndarray) and X.ndim == 1:
         X = X[np.newaxis, :]
 
-    if X.shape[1] != 6:
+    if not addNoise:
+        if X.shape[1] != 5 and X.shape[1] != 6:
+            raise ValueError(f'Input to simulate must have 5 or 6 columns for no noise case, not {X.shape[1]}')
+    elif X.shape[1] != 6:
         raise ValueError(f'Input to simulate must have 6 columns, not {X.shape[1]}')
     
     # Break down the data into 3 parts for separate functions
     X123 = X[:, 0:3]
     X45 = X[:, 3:5]
-    X6 = X[:, 5]
     
     # First three cols represented in an enzyme kinetics problem
     y1 = response_1(X123)
@@ -88,6 +90,7 @@ def OT_simulator(X, addNoise=False, generator=None):
     # Final column has a mean 0 effect, but determines the scale of noise
     # Note: The overall problem is slightly heteroskedastic
     if addNoise:
+        X6 = X[:, 5]
         sd = 0.01+0.02*X6
         if isinstance(generator, Generator):
             rel_error = generator.normal(loc=1, scale=sd, size=y.shape[0])

--- a/obsidian/experiment/design.py
+++ b/obsidian/experiment/design.py
@@ -31,17 +31,24 @@ class ExpDesigner:
     def __init__(self,
                  X_space: ParamSpace,
                  seed: np.random.Generator | int | None = None,
-                 torch_rng: torch.Generator | None = None
+                 torch_rng: torch.Generator | None = None,
+                 np_rng: np.random.Generator | None = None
                  ):
         if not isinstance(X_space, ParamSpace):
             raise TypeError('X_space must be an obsidian ParamSpace object')
-        
+
         self.X_space = X_space
         self.seed = seed
         if torch_rng:
             if not isinstance(torch_rng, torch.Generator):
                 raise TypeError('torch_rng must be a torch.Generator object')
         self.torch_rng = torch_rng
+
+        # Store numpy RNG for future use
+        if np_rng:
+            if not isinstance(np_rng, np.random.Generator):
+                raise TypeError('np_rng must be a numpy.random.Generator object')
+        self.np_rng = np_rng
 
     def __repr__(self):
         """String representation of object"""

--- a/obsidian/experiment/design.py
+++ b/obsidian/experiment/design.py
@@ -6,6 +6,7 @@ from obsidian.parameters import ParamSpace
 from obsidian.exceptions import UnsupportedError
 
 from botorch.utils.sampling import draw_sobol_samples
+import numpy as np
 from numpy.typing import ArrayLike
 from scipy.stats import qmc
 
@@ -29,12 +30,18 @@ class ExpDesigner:
 
     def __init__(self,
                  X_space: ParamSpace,
-                 seed: int | None = None):
+                 seed: np.random.Generator | int | None = None,
+                 torch_rng: torch.Generator | None = None
+                 ):
         if not isinstance(X_space, ParamSpace):
             raise TypeError('X_space must be an obsidian ParamSpace object')
         
         self.X_space = X_space
         self.seed = seed
+        if torch_rng:
+            if not isinstance(torch_rng, torch.Generator):
+                raise TypeError('torch_rng must be a torch.Generator object')
+        self.torch_rng = torch_rng
 
     def __repr__(self):
         """String representation of object"""
@@ -69,9 +76,10 @@ class ExpDesigner:
         seed = self.seed
 
         method_dict = {
+            # TODO: botorch is moving to SPEC-0007, `seed` will be phased out in favor of `rng`
             'LHS': lambda d, m: torch.tensor(
                 qmc.LatinHypercube(d=d, scramble=False, seed=seed, strength=1, optimization='random-cd').random(n=m)),
-            'Random': lambda d, m: torch.rand(size=(m, d)),
+            'Random': lambda d, m: torch.rand(size=(m, d), generator=self.torch_rng),
             'Sobol': lambda d, m: draw_sobol_samples(
                 bounds=torch.tensor([0.0, 1.0]).reshape(2, 1).repeat(1, d), n=m, q=1).squeeze(1),
             'Custom': lambda d, m: torch.tensor(sample_custom),
@@ -109,7 +117,7 @@ class ExpDesigner:
             print(f'The number of initialization experiments ({m}) exceeds the required \
                    number for the requested design ({m_required}). Filling with randomized experiments.')
             excess = m - m_required
-            sample_add = torch.rand(size=(excess, d))
+            sample_add = torch.rand(size=(excess, d), generator=self.torch_rng)
             sample = torch.vstack((sample, sample_add))
 
         sample = pd.DataFrame(sample.numpy(), columns=self.X_space.X_names)

--- a/obsidian/experiment/simulator.py
+++ b/obsidian/experiment/simulator.py
@@ -1,5 +1,6 @@
 """Simulate virtual experimental data"""
 
+from types import ModuleType
 from obsidian.parameters import ParamSpace
 
 from typing import Callable
@@ -7,6 +8,8 @@ import pandas as pd
 import numpy as np
 import warnings
 
+from numpy.random import Generator
+import obsidian
 
 class Simulator:
     """
@@ -34,6 +37,7 @@ class Simulator:
                  response_function: Callable,
                  name: str | list[str] = 'Response',
                  eps: float | list[float] = 0.0,
+                 rng: Generator | int | None = None,
                  **kwargs):
         
         if not callable(response_function):
@@ -45,14 +49,28 @@ class Simulator:
         self.response_function = response_function
         self.name = name
         self.eps = eps if isinstance(eps, list) else [eps]
+        if isinstance(rng, Generator):
+            # use provided numpy generator
+            self.rng: Generator | ModuleType = rng
+        else:
+            self._seed = rng
+            if obsidian.USE_OLD_RNG_CONTROL:
+                # no random state control here
+                self.rng = np.random
+            else:
+                # use new global RNG control
+                # note that if the global RNG is already initialized
+                # and the seed (rng) is different, a ValueError will be raised
+                global_rng = obsidian.get_global_rng(rng)
+                self.rng = global_rng.np_rng
         self.kwargs = kwargs
-    
+
     def __repr__(self):
         """String representation of object"""
         return f" obsidian Simulator(response_function={self.response_function.__name__}, eps={self.eps})"
 
     def simulate(self,
-                 X_prop: pd.DataFrame) -> np.ndarray:
+                 X_prop: pd.DataFrame) -> pd.DataFrame:
         """
         Generates a response to a set of experiments.
 
@@ -76,9 +94,10 @@ class Simulator:
             self.eps *= y_sim.ndim
         if y_sim.ndim == 1:
             y_sim = y_sim.reshape(-1, 1)
-        for i in range(y_sim.shape[1]):
-            rel_error = np.random.normal(loc=1, scale=self.eps[i], size=y_sim.shape[0])
-            y_sim[:, i] *= rel_error
+
+        # vectorized operation
+        rel_error = 1 + self.eps * self.rng.normal(size=y_sim.size).reshape(y_sim.shape)
+        y_sim *= rel_error
 
         # Handle naming conventions
         y_dims = y_sim.shape[1]

--- a/obsidian/experiment/simulator.py
+++ b/obsidian/experiment/simulator.py
@@ -1,6 +1,6 @@
 """Simulate virtual experimental data"""
 
-from types import ModuleType
+from types import ModuleType, MethodType
 from obsidian.parameters import ParamSpace
 
 from typing import Callable
@@ -38,6 +38,7 @@ class Simulator:
                  name: str | list[str] = 'Response',
                  eps: float | list[float] = 0.0,
                  rng: Generator | int | None = None,
+                 error_function: Callable | None = None,
                  **kwargs):
         
         if not callable(response_function):
@@ -63,6 +64,10 @@ class Simulator:
                 # and the seed (rng) is different, a ValueError will be raised
                 global_rng = obsidian.get_global_rng(rng)
                 self.rng = global_rng.np_rng
+        if not error_function:
+            self.error_function = self._default_gaussian_error
+        else:
+            self.error_function = MethodType(error_function, self)
         self.kwargs = kwargs
 
     def __repr__(self):
@@ -88,16 +93,14 @@ class Simulator:
         
         y_sim = self.response_function(X)
         
-        # Apply error
         # Expand length of eps to match number of outputs
         if len(self.eps) == 1:
             self.eps *= y_sim.ndim
         if y_sim.ndim == 1:
             y_sim = y_sim.reshape(-1, 1)
 
-        # vectorized operation
-        rel_error = 1 + self.eps * self.rng.normal(size=y_sim.size).reshape(y_sim.shape)
-        y_sim *= rel_error
+        # Apply error
+        y_sim = self.error_function(X, y_sim)
 
         # Handle naming conventions
         y_dims = y_sim.shape[1]
@@ -114,3 +117,7 @@ class Simulator:
         df_sim = pd.DataFrame(y_sim, columns=self.name)
 
         return df_sim
+
+    def _default_gaussian_error(self, X, y_sim: np.ndarray) -> np.ndarray:
+        rel_error = 1 + self.eps * self.rng.normal(size=y_sim.size).reshape(y_sim.shape)
+        return y_sim * rel_error

--- a/obsidian/experiment/simulator.py
+++ b/obsidian/experiment/simulator.py
@@ -1,7 +1,8 @@
 """Simulate virtual experimental data"""
 
-from types import ModuleType, MethodType
+from types import ModuleType
 from obsidian.parameters import ParamSpace
+from obsidian.rng import RNGManager
 
 from typing import Callable
 import pandas as pd
@@ -24,6 +25,14 @@ class Simulator:
         name (str or list[str]): Name of the simulated output(s). Default is ``Response``.
         eps (float or list[float]): The simulated error to apply, as the standard deviation of the Standard
             Normal distribution. Default is ``0``.
+        apply_noise (Callable | None): Optional custom function to apply noise to the simulated response. 
+            If None, uses default multiplicative Gaussian noise. Must have signature::
+        
+                apply_noise(X, y_sim, eps, rng) -> y_with_noise
+                
+            Where X is the input array, y_sim is the noiseless simulation output with shape 
+            (n_samples, n_outputs), eps is the noise parameter array with shape (1, n_eps), 
+            and rng is the numpy random Generator. Must return array with same shape as y_sim.
         kwargs (dict): Optional hyperparameters for the response function.
 
     Raises:
@@ -37,8 +46,8 @@ class Simulator:
                  response_function: Callable,
                  name: str | list[str] = 'Response',
                  eps: float | list[float] = 0.0,
-                 rng: Generator | int | None = None,
-                 error_function: Callable | None = None,
+                 rng: Generator | RNGManager | int | None = None,
+                 apply_noise: Callable | None = None,
                  **kwargs):
         
         if not callable(response_function):
@@ -49,25 +58,37 @@ class Simulator:
         self.X_space = X_space
         self.response_function = response_function
         self.name = name
-        self.eps = eps if isinstance(eps, list) else [eps]
-        if isinstance(rng, Generator):
+        # We always expect `y_sim` to be no more than 2D
+        # `eps` with more than 1D makes no sense
+        # i.e., one error per output dimension or one error for all dimensions, nothing more
+        # Always converting eps to a 2D array for simplicity
+        # numpy broadcasting will handle the rest
+        self.eps = np.atleast_1d(eps)
+        if self.eps.ndim > 1:
+            raise ValueError(f"eps must be scalar or 1D list/array, got {self.eps.ndim}D array")
+        self.eps = self.eps.reshape(1, -1)
+        if isinstance(rng, RNGManager):
+            self.rng: Generator | ModuleType = rng.np_rng
+            self._seed = rng.seed
+        elif isinstance(rng, Generator):
             # use provided numpy generator
-            self.rng: Generator | ModuleType = rng
+            self.rng = rng
+            self._seed = None
         else:
             self._seed = rng
             if obsidian.USE_OLD_RNG_CONTROL:
                 # no random state control here
                 self.rng = np.random
             else:
-                # use new global RNG control
-                # note that if the global RNG is already initialized
-                # and the seed (rng) is different, a ValueError will be raised
-                global_rng = obsidian.get_global_rng(rng)
-                self.rng = global_rng.np_rng
-        if not error_function:
-            self.error_function = self._default_gaussian_error
+                # use new RNG manager to control random state
+                rng = obsidian.create_rng_manager(rng)
+                self.rng = rng.np_rng
+        if not apply_noise:
+            self.apply_noise = self._default_gaussian_noise
         else:
-            self.error_function = MethodType(error_function, self)
+            if not callable(apply_noise):
+                raise TypeError('Error function must be a callable function')
+            self.apply_noise = apply_noise
         self.kwargs = kwargs
 
     def __repr__(self):
@@ -94,13 +115,13 @@ class Simulator:
         y_sim = self.response_function(X)
         
         # Expand length of eps to match number of outputs
-        if len(self.eps) == 1:
-            self.eps *= y_sim.ndim
+        # if len(self.eps) == 1:
+        #     self.eps *= y_sim.ndim
         if y_sim.ndim == 1:
             y_sim = y_sim.reshape(-1, 1)
 
-        # Apply error
-        y_sim = self.error_function(X, y_sim)
+        # Apply noise to the simulated response
+        y_sim = self.apply_noise(X, y_sim, self.eps, self.rng) # type: ignore
 
         # Handle naming conventions
         y_dims = y_sim.shape[1]
@@ -118,6 +139,9 @@ class Simulator:
 
         return df_sim
 
-    def _default_gaussian_error(self, X, y_sim: np.ndarray) -> np.ndarray:
-        rel_error = 1 + self.eps * self.rng.normal(size=y_sim.size).reshape(y_sim.shape)
-        return y_sim * rel_error
+
+    @staticmethod 
+    def _default_gaussian_noise(X: np.ndarray, y_sim: np.ndarray, eps: np.ndarray, rng: Generator) -> np.ndarray:
+        """Default error function - multiplicative Gaussian noise."""
+        rel_noise = 1 + eps * rng.normal(size=y_sim.shape)
+        return y_sim * rel_noise

--- a/obsidian/experiment/simulator.py
+++ b/obsidian/experiment/simulator.py
@@ -139,6 +139,7 @@ class Simulator:
 
         return df_sim
 
+    #TODO: simulator can have its own random state now, so a save and load state method should be implemented in the future.
 
     @staticmethod 
     def _default_gaussian_noise(X: np.ndarray, y_sim: np.ndarray, eps: np.ndarray, rng: Generator) -> np.ndarray:

--- a/obsidian/experiment/utils.py
+++ b/obsidian/experiment/utils.py
@@ -2,13 +2,15 @@
 from obsidian.exceptions import UnsupportedError
 
 import numpy as np
+from numpy.random import Generator
 from itertools import product
+from types import ModuleType
 
 
 def factorial_DOE(d: int,
                   n_CP: int = 3,
                   shuffle: bool = True,
-                  seed: int | None = None,
+                  seed: Generator | int | None = None,
                   full: bool = False):
     """
     Creates a statistically designed factorial experiment (DOE).
@@ -22,7 +24,7 @@ def factorial_DOE(d: int,
             uncertainty and curvature. Default is ``3``.
         shuffle (bool, optional): Whether or not to shuffle the design or leave them in the default run
             order. Default is ``True``.
-        seed (int, optional): Randomization seed. Default is ``None``.
+        seed (Generator | int | None, optional): Randomization seed or generator for numpy. Default is ``None``.
         full (bool, optional): Whether or not to run the full DOE. Default is ``False``, which
             will lead to an efficient Res4+ design.
 
@@ -72,10 +74,17 @@ def factorial_DOE(d: int,
     
     # Add centerpoints then shuffle
     X = np.vstack((X, CP))
-    if seed is not None:
-        np.random.seed(seed)
+    if isinstance(seed, Generator):
+        # if it is actually a generator
+        rng: Generator | ModuleType = seed
+    else:
+        # with or without a seed, we use np.random for now
+        # in the future, we should instantiate a new random generator from entropy
+        rng = np.random
+        if seed is not None:
+            np.random.seed(seed)
     if shuffle:
-        np.random.shuffle(X)
+        rng.shuffle(X)
     # Rescale from (-1,1) to (0,0.999999)
     X = (X+1)/2 - 1e-6
     

--- a/obsidian/optimizer/base.py
+++ b/obsidian/optimizer/base.py
@@ -46,14 +46,13 @@ class Optimizer(ABC):
         self.verbose = verbose
 
         # Handle randomization seed, considering all 3 sources (torch, random, numpy)
-        self.seed = seed
         # TODO: this part is only for backward compatibility, we should drop it eventually
         if obsidian.USE_OLD_RNG_CONTROL:
-            if self.seed is not None:
-                torch.manual_seed(self.seed)
+            if seed is not None:
+                torch.manual_seed(seed)
                 torch.use_deterministic_algorithms(True)
-                np.random.seed(self.seed)
-                random.seed(self.seed)
+                np.random.seed(seed)
+                random.seed(seed)
             self.torch_rng = None
         else:
             if not rng:
@@ -62,18 +61,20 @@ class Optimizer(ABC):
                 raise TypeError('rng must be an instance of RNGManager')
             else:
                 self.rng = rng
+            seed = self.rng.seed
             self.torch_rng = self.rng.torch_rng
             
             # Create dedicated generator for model operations (fit & suggest)
             # This ensures reproducibility - same initial state gives same seed sequence
             if seed is None:
-                self.seed: int = get_new_seed(1, self.torch_rng) # type: ignore
+                seed: int = get_new_seed(1, self.torch_rng) # type: ignore
             if fix_random_state:
                 self.model_generator = None
             else:
-                self.model_generator = create_torch_rng(self.seed)
+                self.model_generator = create_torch_rng(seed)
             self.fix_random_state = fix_random_state
 
+        self.seed = seed
         # Store the parameter space which contains useful reference properties
         if not isinstance(X_space, ParamSpace):
             raise TypeError('X_space must be an obsidian ParamSpace object')

--- a/obsidian/optimizer/base.py
+++ b/obsidian/optimizer/base.py
@@ -1,5 +1,6 @@
 """Optimizer class definition"""
 
+import obsidian
 from obsidian.parameters import ParamSpace, Target, Param_Observational
 from obsidian.exceptions import UnsupportedError
 
@@ -12,6 +13,8 @@ import numpy as np
 import torch
 import random
 from torch import Tensor
+
+from obsidian.rng import GlobalRNG, dummy_decorator
 
 
 class Optimizer(ABC):
@@ -32,6 +35,7 @@ class Optimizer(ABC):
     def __init__(self,
                  X_space: ParamSpace,
                  seed: int | None = None,
+                 global_rng: GlobalRNG | None = None,
                  verbose: int = 1):
         
         # Verbose selection
@@ -42,11 +46,26 @@ class Optimizer(ABC):
 
         # Handle randomization seed, considering all 3 sources (torch, random, numpy)
         self.seed = seed
-        if self.seed is not None:
-            torch.manual_seed(self.seed)
-            torch.use_deterministic_algorithms(True)
-            np.random.seed(self.seed)
-            random.seed(self.seed)
+        # TODO: this part is only for backward compatibility, we should drop it eventually
+        if obsidian.USE_OLD_RNG_CONTROL:
+            if self.seed is not None:
+                torch.manual_seed(self.seed)
+                torch.use_deterministic_algorithms(True)
+                np.random.seed(self.seed)
+                random.seed(self.seed)
+            self.rng_decorator = dummy_decorator
+            self.fit = self.rng_decorator(self.fit)
+            self.torch_rng = None
+        else:
+            if not global_rng:
+                self.global_rng = obsidian.get_global_rng(seed)
+            elif not isinstance(global_rng, GlobalRNG):
+                raise TypeError('global_rng must be an instance of GlobalRNG')
+            else:
+                self.global_rng = global_rng
+            self.torch_rng = self.global_rng.torch_rng
+            self.rng_decorator = self.global_rng.tmp_seed_override
+            self.fit = self.rng_decorator(self.fit)
 
         # Store the parameter space which contains useful reference properties
         if not isinstance(X_space, ParamSpace):
@@ -217,9 +236,7 @@ class Optimizer(ABC):
         return min_distance
 
     @abstractmethod
-    def fit(self,
-            Z: pd.DataFrame,
-            target: Target | list[Target]):
+    def fit(self, Z: pd.DataFrame, target: Target | list[Target], fit_options: dict):
         """Fit the optimizer's surrogate models to data"""
         pass  # pragma: no cover
 

--- a/obsidian/optimizer/base.py
+++ b/obsidian/optimizer/base.py
@@ -14,7 +14,7 @@ import torch
 import random
 from torch import Tensor
 
-from obsidian.rng import GlobalRNG, dummy_decorator
+from obsidian.rng import RNGManager, get_new_seed, create_torch_rng
 
 
 class Optimizer(ABC):
@@ -35,11 +35,12 @@ class Optimizer(ABC):
     def __init__(self,
                  X_space: ParamSpace,
                  seed: int | None = None,
-                 global_rng: GlobalRNG | None = None,
+                 rng: RNGManager | None = None,
+                 fix_random_state: bool = True,
                  verbose: int = 1):
         
         # Verbose selection
-        if verbose not in [0, 1, 2, 3]:
+        if verbose not in {0, 1, 2, 3}:
             raise ValueError('Verbose option must be 0 (no output), 1 (summary output), \
                              2 (detailed output), or 3 (debugging)')
         self.verbose = verbose
@@ -53,19 +54,25 @@ class Optimizer(ABC):
                 torch.use_deterministic_algorithms(True)
                 np.random.seed(self.seed)
                 random.seed(self.seed)
-            self.rng_decorator = dummy_decorator
-            self.fit = self.rng_decorator(self.fit)
             self.torch_rng = None
         else:
-            if not global_rng:
-                self.global_rng = obsidian.get_global_rng(seed)
-            elif not isinstance(global_rng, GlobalRNG):
-                raise TypeError('global_rng must be an instance of GlobalRNG')
+            if not rng:
+                self.rng = obsidian.create_rng_manager(seed)
+            elif not isinstance(rng, RNGManager):
+                raise TypeError('rng must be an instance of RNGManager')
             else:
-                self.global_rng = global_rng
-            self.torch_rng = self.global_rng.torch_rng
-            self.rng_decorator = self.global_rng.tmp_seed_override
-            self.fit = self.rng_decorator(self.fit)
+                self.rng = rng
+            self.torch_rng = self.rng.torch_rng
+            
+            # Create dedicated generator for model operations (fit & suggest)
+            # This ensures reproducibility - same initial state gives same seed sequence
+            if seed is None:
+                self.seed: int = get_new_seed(1, self.torch_rng) # type: ignore
+            if fix_random_state:
+                self.model_generator = None
+            else:
+                self.model_generator = create_torch_rng(self.seed)
+            self.fix_random_state = fix_random_state
 
         # Store the parameter space which contains useful reference properties
         if not isinstance(X_space, ParamSpace):
@@ -235,9 +242,33 @@ class Optimizer(ABC):
         
         return min_distance
 
+    def fit(self, Z: pd.DataFrame, target: Target | list[Target], manual_seed: int | None = None, fit_options: dict = {}):
+        """Fit surrogate model(s) using observed data.
+
+        This is a wrapper around :meth:`_fit` that handles RNG behavior for
+        backward compatibility:
+        - If ``obsidian.USE_OLD_RNG_CONTROL`` is ``True``, calls ``_fit`` directly.
+        - Otherwise, temporarily applies ``manual_seed`` via ``tmp_seed_override`` and
+          then calls ``_fit``.
+
+        Args:
+            Z (pd.DataFrame): Observation table containing input variables and
+                measured target values used for training.
+            target (Target | list[Target]): One target or a list of targets to fit.
+            manual_seed (int | None, optional): Temporary seed used only for this fit call when new RNG control is
+                enabled. If ``None``, a seed is sampled from the optimizer's model_generator. Defaults to ``None``.
+            fit_options (dict, optional): Extra options forwarded to model.fit(). Refer to model's ``fit`` method for
+                supported options. Defaults to an empty dictionary.
+
+        Returns:
+            None: Fit the surrogate model(s) in-place.
+        """
+        fit_with_seed = self._rng_wrapper(self._fit, manual_seed)
+        return fit_with_seed(Z, target, fit_options)
+
     @abstractmethod
-    def fit(self, Z: pd.DataFrame, target: Target | list[Target], fit_options: dict):
-        """Fit the optimizer's surrogate models to data"""
+    def _fit(self, Z: pd.DataFrame, target: Target | list[Target], fit_options: dict) -> None:
+        """Actual method to fit the optimizer's surrogate models to data"""
         pass  # pragma: no cover
 
     @abstractmethod
@@ -259,13 +290,39 @@ class Optimizer(ABC):
         pass  # pragma: no cover
 
     @abstractmethod
-    def save_state(self):
+    def save_state(self) -> dict:
         """Save the optimizer to a state dictionary"""
         pass  # pragma: no cover
     
     @classmethod
     @abstractmethod
-    def load_state(cls,
-                   obj_dict: dict):
+    def load_state(cls, obj_dict: dict):
         """Load the optimizer from a state dictionary"""
         pass  # pragma: no cover
+
+    def _rng_wrapper(self, func, manual_seed: int | None = None):
+        """
+        Helper to apply RNG seeding control to a function call.
+    
+        Consolidates the seed selection logic (manual_seed > model_generator > self.seed)
+        and applies tmp_seed_override for backward compatibility with USE_OLD_RNG_CONTROL.
+    
+        Args:
+            func: Function to wrap with RNG control
+            manual_seed: Optional manual seed override
+    
+        Returns:
+            Wrapped function ready to be called
+        """
+        if obsidian.USE_OLD_RNG_CONTROL:
+            return func
+        else:
+            # Seed priority: manual_seed > model_generator > self.seed
+            if manual_seed is not None:
+                seed = manual_seed
+            elif self.model_generator:
+                seed = get_new_seed(1, self.model_generator)
+            else:
+                seed = self.seed
+
+            return self.rng.tmp_seed_override(func, seed)  # type: ignore

--- a/obsidian/optimizer/bayesian.py
+++ b/obsidian/optimizer/bayesian.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 import obsidian
-from obsidian.rng import GlobalRNG
+from obsidian.rng import RNGManager, create_torch_rng, get_new_seed
 from .base import Optimizer
 
 from obsidian.parameters import ParamSpace, Target, Task
@@ -80,10 +80,11 @@ class BayesianOptimizer(Optimizer):
                  X_space: ParamSpace,
                  surrogate: str | dict | list[str] | list[dict] = 'GP',
                  seed: int | None = None,
-                 global_rng: GlobalRNG | None = None,
+                 rng: RNGManager | None = None,
+                 fix_random_state: bool = True,
                  verbose: int = 1):
-       
-        super().__init__(X_space=X_space, seed=seed, global_rng=global_rng, verbose=verbose)
+
+        super().__init__(X_space=X_space, seed=seed, rng=rng, fix_random_state=fix_random_state, verbose=verbose)
 
         self.surrogate_type = []  # Shorthand name as str (as provided)
         self.surrogate_hps = []  # Hyperparameters
@@ -170,9 +171,10 @@ class BayesianOptimizer(Optimizer):
                     raise TypeError('Each item in target must be a Target object')
         return target
 
-    def fit(self, Z: pd.DataFrame, target: Target | list[Target], fit_options: dict = {}):
+    def _fit(self, Z: pd.DataFrame, target: Target | list[Target], fit_options: dict = {}):
         """
-        Fits the BO surrogate model to data.
+        Fits the BO surrogate model to data. The user-facing ``fit`` method is inherited from the base Optimizer class,
+        which handles RNG control and then calls this method to perform the actual fitting.
 
         Args:
             Z (pd.DataFrame): Total dataset including inputs (X) and response values (y)
@@ -226,48 +228,40 @@ class BayesianOptimizer(Optimizer):
 
         # Instantiate and fit the model(s)
         self.surrogate = []
-        # with USE_OLD_RNG_CONTROL, this decorator is dummy
-        # otherwise the decorator will activate a context manager to temporarily set the RNG seeds
-        @self.rng_decorator
-        def fit_models():
-            """A wrapper switching between new (context manager) and old (manual) RNG behavior."""
-            for i in range(self.n_response):
-                model = SurrogateBoTorch(
-                    model_type=self.surrogate_type[i],
-                    seed=self.seed,
-                    verbose=self.verbose >= 2,
-                    hps=self.surrogate_hps[i],
-                )
+        for i in range(self.n_response):
+            model = SurrogateBoTorch(
+                model_type=self.surrogate_type[i],
+                seed=self.seed,
+                verbose=self.verbose >= 2,
+                hps=self.surrogate_hps[i],
+            )
 
-                # Handle response NaN values on a response-by-response basis
-                f_train_i = self.f_train.iloc[:, i]
-                nan_indices = np.where(f_train_i.isna().values)[0]
-                X_t_train_valid = self.X_t_train.drop(nan_indices)
-                f_train_i_valid = f_train_i.drop(nan_indices)
-                if X_t_train_valid.shape[0] < 1:
-                    raise ValueError(f'No valid data points for response {self.y_names[i]}')
-                if f_train_i_valid.shape[0] < 1:
-                    raise ValueError(f'No valid response data points for response {self.y_names[i]}')
+            # Handle response NaN values on a response-by-response basis
+            f_train_i = self.f_train.iloc[:, i]
+            nan_indices = np.where(f_train_i.isna().values)[0]
+            X_t_train_valid = self.X_t_train.drop(nan_indices)
+            f_train_i_valid = f_train_i.drop(nan_indices)
+            if X_t_train_valid.shape[0] < 1:
+                raise ValueError(f'No valid data points for response {self.y_names[i]}')
+            if f_train_i_valid.shape[0] < 1:
+                raise ValueError(f'No valid response data points for response {self.y_names[i]}')
 
-                # Fit the model for each response
-                model.fit(
-                    X_t_train_valid,
-                    f_train_i_valid,
-                    cat_dims=self.X_space.X_t_cat_idx,
-                    task_feature=self.X_space.X_t_task_idx,
-                    **fit_options,
-                )
+            # Fit the model for each response
+            model.fit(
+                X_t_train_valid,
+                f_train_i_valid,
+                cat_dims=self.X_space.X_t_cat_idx,
+                task_feature=self.X_space.X_t_task_idx,
+                **fit_options,
+            )
 
-                if self.verbose >= 1:
-                    print(f'{self.surrogate_type[i]} model has been fit to data'
-                          + f' with an R2-train-score of: {model.r2_score:.3g}'
-                          + (f' and a training-loss of: {model.loss:.3g}' if self.verbose >= 2 else '')
-                          + f' for response: {self.y_names[i]}')
-                self.surrogate.append(model)
-
-        fit_models()
+            if self.verbose >= 1:
+                print(f'{self.surrogate_type[i]} model has been fit to data'
+                      + f' with an R2-train-score of: {model.r2_score:.3g}'
+                      + (f' and a training-loss of: {model.loss:.3g}' if self.verbose >= 2 else '')
+                      + f' for response: {self.y_names[i]}')
+            self.surrogate.append(model)
     
-    # TODO: incorporate new global RNG
     def save_state(self) -> dict:
         """
         Saves the parameters of the Bayesian Optimizer so that they can be reloaded without fitting.
@@ -299,6 +293,13 @@ class BayesianOptimizer(Optimizer):
             else:
                 config_save['opt_attrs'][attr] = getattr(self, attr)
 
+        # Save RNG state if new RNG control is enabled
+        if not obsidian.USE_OLD_RNG_CONTROL:
+            config_save['rng_state'] = self.rng.save_state()
+            config_save['fix_random_state'] = hasattr(self, 'model_generator') and self.model_generator is None
+            if self.model_generator:
+                config_save['model_generator_state'] = self.model_generator.get_state().cpu().tolist()
+
         # Unpack the fit parameters of each surrogate model, if present
         if self.surrogate:
             model_states = []
@@ -313,7 +314,6 @@ class BayesianOptimizer(Optimizer):
     def __repr__(self):
         return f'BayesianOptimizer(X_space={self.X_space}, surrogate={self.surrogate_type}, target={getattr(self, "target", None)})'
 
-    # TODO: incorporate new global RNG
     @classmethod
     def load_state(cls,
                    config_save: dict):
@@ -330,9 +330,26 @@ class BayesianOptimizer(Optimizer):
             ValueError: If the number of saved models does not match the number of named models.
         """
 
+        # Restore RNG state if saved
+        rng = None
+        fix_random_state = True
+        if 'rng_state' in config_save:
+            rng = RNGManager.load_state(config_save['rng_state'])
+            fix_random_state = config_save.get('fix_random_state', True)
+
+        seed = config_save.get('seed', None)
+
         new_opt = cls(X_space=ParamSpace.load_state(config_save['X_space']),
-                      surrogate=config_save['surrogate_spec'])
+                      surrogate=config_save['surrogate_spec'],
+                      seed=seed,
+                      rng=rng,
+                      fix_random_state=fix_random_state)
         new_opt.target = [Target.load_state(t) for t in config_save['target']]
+
+        # Restore model_generator state if saved
+        if 'model_generator_state' in config_save:
+            tmp_rng = create_torch_rng(0)
+            new_opt.model_generator = tmp_rng.set_state(torch.ByteTensor(config_save['model_generator_state']))
 
         # Directly unpack all of the entries in opt_attrs
         for k, v in config_save['opt_attrs'].items():
@@ -613,7 +630,8 @@ class BayesianOptimizer(Optimizer):
                 task_index: int = 0,
                 fixed_var: dict[str: float | str] | None = None,
                 X_pending: pd.DataFrame | None = None,
-                eval_pending: pd.DataFrame | None = None) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+                eval_pending: pd.DataFrame | None = None,
+                manual_seed: int | None = None) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
         """
         Suggest future experiments based on a maximization of some acquisition
         function calculated from the expectation of a surrogate model.
@@ -852,7 +870,6 @@ class BayesianOptimizer(Optimizer):
                                    Setting optim_sequential to False', UserWarning)
                     optim_sequential = False
 
-            @self.rng_decorator
             def optimize_acqf_wrapper(fixed_features_list):
                 if fixed_features_list:
                     # If there are any discrete values, we must used the mixed integer optimization
@@ -865,7 +882,7 @@ class BayesianOptimizer(Optimizer):
                 candidates, _ = optim_func(
                     acq_function=aq_func,
                     bounds=X_bounds,
-                    q=m_batch,  
+                    q=m_batch,
                     num_restarts=optim_restarts,
                     raw_samples=optim_samples,
                     options=optim_options,
@@ -879,7 +896,9 @@ class BayesianOptimizer(Optimizer):
             else:
                 aq_func = aq_class_dict[aq_str](**aq_kwargs).to(TORCH_DTYPE)
 
-                candidates, _ = optimize_acqf_wrapper(fixed_features_list)
+                # Wrap with RNG control
+                wrapped_func = self._rng_wrapper(optimize_acqf_wrapper, manual_seed)
+                candidates, _ = wrapped_func(fixed_features_list)
 
             if self.verbose >= 2:
                 print(f'Optimized {aq_str} acquisition function successfully')

--- a/obsidian/optimizer/bayesian.py
+++ b/obsidian/optimizer/bayesian.py
@@ -337,7 +337,7 @@ class BayesianOptimizer(Optimizer):
             rng = RNGManager.load_state(config_save['rng_state'])
             fix_random_state = config_save.get('fix_random_state', True)
 
-        seed = config_save.get('seed', None)
+        seed = config_save['opt_attrs'].get('seed', None)
 
         new_opt = cls(X_space=ParamSpace.load_state(config_save['X_space']),
                       surrogate=config_save['surrogate_spec'],

--- a/obsidian/optimizer/bayesian.py
+++ b/obsidian/optimizer/bayesian.py
@@ -857,6 +857,7 @@ class BayesianOptimizer(Optimizer):
                 if fixed_features_list:
                     # If there are any discrete values, we must used the mixed integer optimization
                     optim_func = optimize_acqf_mixed
+                    optim_kwargs["fixed_features_list"] = fixed_features_list
                 else:
                     optim_func = optimize_acqf
                     optim_kwargs["sequential"] = optim_sequential
@@ -864,7 +865,6 @@ class BayesianOptimizer(Optimizer):
                 candidates, _ = optim_func(
                     acq_function=aq_func,
                     bounds=X_bounds,
-                    fixed_features_list=fixed_features_list,
                     q=m_batch,  
                     num_restarts=optim_restarts,
                     raw_samples=optim_samples,

--- a/obsidian/optimizer/bayesian.py
+++ b/obsidian/optimizer/bayesian.py
@@ -1,5 +1,8 @@
 """Bayesian Optimization: Select experiments from the predicted posterior and update the prior"""
 
+from typing import Any
+import obsidian
+from obsidian.rng import GlobalRNG
 from .base import Optimizer
 
 from obsidian.parameters import ParamSpace, Target, Task
@@ -28,8 +31,6 @@ import pandas as pd
 import numpy as np
 import warnings
 
-UNIQUE_SEEDS = False
-UNIQUE_SEEDS_SAMPLER = False
 
 class BayesianOptimizer(Optimizer):
     """
@@ -79,16 +80,10 @@ class BayesianOptimizer(Optimizer):
                  X_space: ParamSpace,
                  surrogate: str | dict | list[str] | list[dict] = 'GP',
                  seed: int | None = None,
+                 global_rng: GlobalRNG | None = None,
                  verbose: int = 1):
        
-        super().__init__(X_space=X_space, seed=seed, verbose=verbose)
-        print("  Optimizer seed", seed)
-
-        if UNIQUE_SEEDS:
-            if seed is not None:
-                self.optimizer_rng = torch.Generator().manual_seed(seed)
-            else:
-                self.optimizer_rng = torch.Generator()
+        super().__init__(X_space=X_space, seed=seed, global_rng=global_rng, verbose=verbose)
 
         self.surrogate_type = []  # Shorthand name as str (as provided)
         self.surrogate_hps = []  # Hyperparameters
@@ -130,8 +125,7 @@ class BayesianOptimizer(Optimizer):
             if surrogate_str not in model_class_dict.keys():
                 raise KeyError(f'Surrogate model must be selected from one of: {model_class_dict.keys()}')
 
-        return
-    
+
     @property
     def is_fit(self):
         """
@@ -176,9 +170,7 @@ class BayesianOptimizer(Optimizer):
                     raise TypeError('Each item in target must be a Target object')
         return target
 
-    def fit(self,
-            Z: pd.DataFrame,
-            target: Target | list[Target]):
+    def fit(self, Z: pd.DataFrame, target: Target | list[Target], fit_options: dict = {}):
         """
         Fits the BO surrogate model to data.
 
@@ -186,6 +178,7 @@ class BayesianOptimizer(Optimizer):
             Z (pd.DataFrame): Total dataset including inputs (X) and response values (y)
             target (Target or list of Target): The responses (y) to be used for optimization,
                 packed into a Target object or list thereof
+            fit_options (dict, optional): Additional options to customize the fitting process. Refer to the model's `fit` method for details.
 
         Returns:
             None. Updates the model in self.surrogate
@@ -232,38 +225,49 @@ class BayesianOptimizer(Optimizer):
         self.X_best_f = self.X_train.iloc[self.X_best_f_idx, :].to_frame().T
 
         # Instantiate and fit the model(s)
-        if UNIQUE_SEEDS:
-            model_seed = torch.randint(0, 1_000_000, (1,), generator=self.optimizer_rng).item()
-        else:
-            model_seed = self.seed
-        print("    Model seed", model_seed)
         self.surrogate = []
-        for i in range(self.n_response):
-            self.surrogate.append(
-                SurrogateBoTorch(model_type=self.surrogate_type[i], seed=model_seed,
-                                 verbose=self.verbose >= 2, hps=self.surrogate_hps[i]))
-            
-            # Handle response NaN values on a response-by-response basis
-            f_train_i = self.f_train.iloc[:, i]
-            nan_indices = np.where(f_train_i.isna().values)[0]
-            X_t_train_valid = self.X_t_train.drop(nan_indices)
-            f_train_i_valid = f_train_i.drop(nan_indices)
-            if X_t_train_valid.shape[0] < 1:
-                raise ValueError(f'No valid data points for response {self.y_names[i]}')
-            if f_train_i_valid.shape[0] < 1:
-                raise ValueError(f'No valid response data points for response {self.y_names[i]}')
-            
-            # Fit the model for each response
-            self.surrogate[i].fit(X_t_train_valid, f_train_i_valid,
-                                  cat_dims=self.X_space.X_t_cat_idx, task_feature=self.X_space.X_t_task_idx)
-            
-            if self.verbose >= 1:
-                print(f'{self.surrogate_type[i]} model has been fit to data'
-                      + f' with an R2-train-score of: {self.surrogate[i].r2_score:.3g}'
-                      + (f' and a training-loss of: {self.surrogate[i].loss:.3g}' if self.verbose >= 2 else '')
-                      + f' for response: {self.y_names[i]}')
-        return
+        # with USE_OLD_RNG_CONTROL, this decorator is dummy
+        # otherwise the decorator will activate a context manager to temporarily set the RNG seeds
+        @self.rng_decorator
+        def fit_models():
+            """A wrapper switching between new (context manager) and old (manual) RNG behavior."""
+            for i in range(self.n_response):
+                model = SurrogateBoTorch(
+                    model_type=self.surrogate_type[i],
+                    seed=self.seed,
+                    verbose=self.verbose >= 2,
+                    hps=self.surrogate_hps[i],
+                )
+
+                # Handle response NaN values on a response-by-response basis
+                f_train_i = self.f_train.iloc[:, i]
+                nan_indices = np.where(f_train_i.isna().values)[0]
+                X_t_train_valid = self.X_t_train.drop(nan_indices)
+                f_train_i_valid = f_train_i.drop(nan_indices)
+                if X_t_train_valid.shape[0] < 1:
+                    raise ValueError(f'No valid data points for response {self.y_names[i]}')
+                if f_train_i_valid.shape[0] < 1:
+                    raise ValueError(f'No valid response data points for response {self.y_names[i]}')
+
+                # Fit the model for each response
+                model.fit(
+                    X_t_train_valid,
+                    f_train_i_valid,
+                    cat_dims=self.X_space.X_t_cat_idx,
+                    task_feature=self.X_space.X_t_task_idx,
+                    **fit_options,
+                )
+
+                if self.verbose >= 1:
+                    print(f'{self.surrogate_type[i]} model has been fit to data'
+                          + f' with an R2-train-score of: {model.r2_score:.3g}'
+                          + (f' and a training-loss of: {model.loss:.3g}' if self.verbose >= 2 else '')
+                          + f' for response: {self.y_names[i]}')
+                self.surrogate.append(model)
+
+        fit_models()
     
+    # TODO: incorporate new global RNG
     def save_state(self) -> dict:
         """
         Saves the parameters of the Bayesian Optimizer so that they can be reloaded without fitting.
@@ -309,6 +313,7 @@ class BayesianOptimizer(Optimizer):
     def __repr__(self):
         return f'BayesianOptimizer(X_space={self.X_space}, surrogate={self.surrogate_type}, target={getattr(self, "target", None)})'
 
+    # TODO: incorporate new global RNG
     @classmethod
     def load_state(cls,
                    config_save: dict):
@@ -599,6 +604,7 @@ class BayesianOptimizer(Optimizer):
                 optim_sequential: bool = True,
                 optim_samples: int = 512,
                 optim_restarts: int = 10,
+                optim_options: dict | None = None,
                 objective: MCAcquisitionObjective | None = None,
                 out_constraints: Output_Constraint | list[Output_Constraint] | None = None,
                 eq_constraints: Linear_Constraint | list[Linear_Constraint] | None = None,
@@ -650,6 +656,7 @@ class BayesianOptimizer(Optimizer):
                 The default value is ``512``.
             optim_restarts (int, optional): The number of restarts to use in the global optimization
                 of the acquisition function. The default value is ``10``.
+            optim_options (dict, optional): Options to pass to the optimization routine directly. Refer to BoTorch's `optimize_acqf` function family, `gen_candidates_scipy`, `gen_candidates_torch`, and `scipy.optimize.minimize` for possible options.
             objective (MCAcquisitionObjective, optional): The objective function to be used for optimization.
                 The default is ``None``.
             out_constraints (Output_Constraint | list[Output_Constraint], optional): An output constraint, or a list
@@ -733,21 +740,17 @@ class BayesianOptimizer(Optimizer):
                           + ' Recommend reducing the number of discrete parameters used.', OptimizerWarning)
         
         # Set up the sampler, for MC-based optimization of acquisition functions
-        if UNIQUE_SEEDS_SAMPLER:
-            sampler_seed = torch.randint(0, 1_000_000, (1,), generator=self.optimizer_rng).item()
-        else:
-            sampler_seed = self.seed
         if not isinstance(model, ModelListGP):
             samplers = []
             for m in model.models:
                 if isinstance(m, EnsembleModel):
-                    sampler_i = IndexSampler(sample_shape=torch.Size([optim_samples]), seed=sampler_seed)
+                    sampler_i = IndexSampler(sample_shape=torch.Size([optim_samples]), seed=self.seed)
                 else:
-                    sampler_i = SobolQMCNormalSampler(sample_shape=torch.Size([optim_samples]), seed=sampler_seed)
+                    sampler_i = SobolQMCNormalSampler(sample_shape=torch.Size([optim_samples]), seed=self.seed)
                 samplers.append(sampler_i)
             sampler = ListSampler(*samplers)
         else:
-            sampler = SobolQMCNormalSampler(sample_shape=torch.Size([optim_samples]), seed=sampler_seed)
+            sampler = SobolQMCNormalSampler(sample_shape=torch.Size([optim_samples]), seed=self.seed)
 
         # Calculate search bounds for optimization
         X_bounds = torch.tensor(self.X_space.search_space.values, dtype=TORCH_DTYPE)
@@ -826,16 +829,18 @@ class BayesianOptimizer(Optimizer):
                 nleq_constraints += self.X_space.nonlinear_constraints
 
             # Input constraints are used by optim_acqf and friends
-            optim_kwargs = {'equality_constraints': [c() for c in eq_constraints] if eq_constraints else None,
-                            'inequality_constraints': [c() for c in ineq_constraints] if ineq_constraints else None,
-                            'nonlinear_inequality_constraints': [c() for c in nleq_constraints] if nleq_constraints else None}
+            optim_kwargs: dict[str, Any] = {
+                "equality_constraints": [c() for c in eq_constraints] if eq_constraints else None,
+                "inequality_constraints": [c() for c in ineq_constraints] if ineq_constraints else None,
+                "nonlinear_inequality_constraints": [c() for c in nleq_constraints] if nleq_constraints else None,
+            }
             
-            optim_options = {}  # Can optionally specify batch_limit or max_iter
+            # optim_options = {}  # Can optionally specify batch_limit or max_iter
             
             # If nonlinear constraints are used, BoTorch doesn't provide an ic_generator
             # Must provide manual samples = just use random initialization
             if nleq_constraints:
-                X_ic = torch.ones((optim_samples, 1 if fixed_features_list else m_batch, self.X_space.n_tdim))*torch.rand(1)
+                X_ic = torch.ones((optim_samples, 1 if fixed_features_list else m_batch, self.X_space.n_tdim))*torch.rand(1, generator=self.torch_rng)
                 optim_kwargs['batch_initial_conditions'] = X_ic
                 if fixed_features_list:
                     raise UnsupportedError('Nonlinear constraints are not supported with discrete features.')
@@ -847,28 +852,35 @@ class BayesianOptimizer(Optimizer):
                                    Setting optim_sequential to False', UserWarning)
                     optim_sequential = False
 
+            @self.rng_decorator
+            def optimize_acqf_wrapper(fixed_features_list):
+                if fixed_features_list:
+                    # If there are any discrete values, we must used the mixed integer optimization
+                    optim_func = optimize_acqf_mixed
+                else:
+                    optim_func = optimize_acqf
+                    optim_kwargs["sequential"] = optim_sequential
+
+                candidates, _ = optim_func(
+                    acq_function=aq_func,
+                    bounds=X_bounds,
+                    fixed_features_list=fixed_features_list,
+                    q=m_batch,  
+                    num_restarts=optim_restarts,
+                    raw_samples=optim_samples,
+                    options=optim_options,
+                    **optim_kwargs,
+                )
+                return candidates, _
+
             # If it's random search, no need to do optimization; Otherwise, initialize the aq function and optimize
             if aq_str == 'RS':
-                candidates = torch.rand((m_batch, self.X_space.n_tdim), dtype=TORCH_DTYPE)
+                candidates = torch.rand((m_batch, self.X_space.n_tdim), generator=self.torch_rng, dtype=TORCH_DTYPE)
             else:
                 aq_func = aq_class_dict[aq_str](**aq_kwargs).to(TORCH_DTYPE)
-                
-                # If there are any discrete values, we must used the mixed integer optimization
-                if fixed_features_list:
-                    candidates, _ = optimize_acqf_mixed(acq_function=aq_func, bounds=X_bounds,
-                                                        fixed_features_list=fixed_features_list,
-                                                        q=m_batch,  # Always sequential
-                                                        num_restarts=optim_restarts, raw_samples=optim_samples,
-                                                        options=optim_options,
-                                                        **optim_kwargs)
-                else:
-                    candidates, _ = optimize_acqf(acq_function=aq_func, bounds=X_bounds,
-                                                  q=m_batch,
-                                                  sequential=optim_sequential,
-                                                  num_restarts=optim_restarts, raw_samples=optim_samples,
-                                                  options=optim_options,
-                                                  **optim_kwargs)
-            
+
+                candidates, _ = optimize_acqf_wrapper(fixed_features_list)
+
             if self.verbose >= 2:
                 print(f'Optimized {aq_str} acquisition function successfully')
             

--- a/obsidian/optimizer/bayesian.py
+++ b/obsidian/optimizer/bayesian.py
@@ -28,6 +28,8 @@ import pandas as pd
 import numpy as np
 import warnings
 
+UNIQUE_SEEDS = False
+UNIQUE_SEEDS_SAMPLER = False
 
 class BayesianOptimizer(Optimizer):
     """
@@ -80,6 +82,13 @@ class BayesianOptimizer(Optimizer):
                  verbose: int = 1):
        
         super().__init__(X_space=X_space, seed=seed, verbose=verbose)
+        print("  Optimizer seed", seed)
+
+        if UNIQUE_SEEDS:
+            if seed is not None:
+                self.optimizer_rng = torch.Generator().manual_seed(seed)
+            else:
+                self.optimizer_rng = torch.Generator()
 
         self.surrogate_type = []  # Shorthand name as str (as provided)
         self.surrogate_hps = []  # Hyperparameters
@@ -223,10 +232,15 @@ class BayesianOptimizer(Optimizer):
         self.X_best_f = self.X_train.iloc[self.X_best_f_idx, :].to_frame().T
 
         # Instantiate and fit the model(s)
+        if UNIQUE_SEEDS:
+            model_seed = torch.randint(0, 1_000_000, (1,), generator=self.optimizer_rng).item()
+        else:
+            model_seed = self.seed
+        print("    Model seed", model_seed)
         self.surrogate = []
         for i in range(self.n_response):
             self.surrogate.append(
-                SurrogateBoTorch(model_type=self.surrogate_type[i], seed=self.seed,
+                SurrogateBoTorch(model_type=self.surrogate_type[i], seed=model_seed,
                                  verbose=self.verbose >= 2, hps=self.surrogate_hps[i]))
             
             # Handle response NaN values on a response-by-response basis
@@ -719,18 +733,22 @@ class BayesianOptimizer(Optimizer):
                           + ' Recommend reducing the number of discrete parameters used.', OptimizerWarning)
         
         # Set up the sampler, for MC-based optimization of acquisition functions
+        if UNIQUE_SEEDS_SAMPLER:
+            sampler_seed = torch.randint(0, 1_000_000, (1,), generator=self.optimizer_rng).item()
+        else:
+            sampler_seed = self.seed
         if not isinstance(model, ModelListGP):
             samplers = []
             for m in model.models:
                 if isinstance(m, EnsembleModel):
-                    sampler_i = IndexSampler(sample_shape=torch.Size([optim_samples]), seed=self.seed)
+                    sampler_i = IndexSampler(sample_shape=torch.Size([optim_samples]), seed=sampler_seed)
                 else:
-                    sampler_i = SobolQMCNormalSampler(sample_shape=torch.Size([optim_samples]), seed=self.seed)
+                    sampler_i = SobolQMCNormalSampler(sample_shape=torch.Size([optim_samples]), seed=sampler_seed)
                 samplers.append(sampler_i)
             sampler = ListSampler(*samplers)
         else:
-            sampler = SobolQMCNormalSampler(sample_shape=torch.Size([optim_samples]), seed=self.seed)
-            
+            sampler = SobolQMCNormalSampler(sample_shape=torch.Size([optim_samples]), seed=sampler_seed)
+
         # Calculate search bounds for optimization
         X_bounds = torch.tensor(self.X_space.search_space.values, dtype=TORCH_DTYPE)
         

--- a/obsidian/parameters/param_space.py
+++ b/obsidian/parameters/param_space.py
@@ -28,6 +28,8 @@ from obsidian.constraints import (
 from obsidian.exceptions import UnsupportedError
 from obsidian.utils import tensordict_to_dict
 
+from typing import Sequence
+
 import torch
 import numpy as np
 import pandas as pd
@@ -66,7 +68,7 @@ class ParamSpace(IParamSpace):
 
     """
     def __init__(self,
-                 params: list[Parameter]):
+                 params: Sequence[Parameter]):
         
         # Convert to immutable dtype to presever order
         self.params = tuple(params)

--- a/obsidian/rng.py
+++ b/obsidian/rng.py
@@ -1,0 +1,160 @@
+import random
+import time
+from contextlib import contextmanager
+from functools import partial
+
+import numpy as np
+import torch
+
+
+class GlobalRNG:
+    """
+    A class to manage global random number generation for reproducibility and statistical integrity.
+    """
+
+    def __init__(self, seed: int | None = None):
+        # if seed is none, get a seed from current time and save it
+        if seed is None:
+            # time.time() * 1e6 gives microseconds level accuracy
+            seed = int(time.time() * 1e6) % (2**32 - 1)
+        self.seed = seed
+        torch.use_deterministic_algorithms(True)
+        self.np_rng = np.random.default_rng(seed)
+        self.torch_rng = torch.Generator().manual_seed(seed)
+        print(
+            f"numpy and torch random number generators initialized with seed {seed}. "
+            "Please reuse this seed to reproduce the results."
+        )
+
+    def tmp_seed_override(self, func):
+        """Decorator that samples a seed from the global RNG and temporarily overrides the global random states (numpy, torch, random) for the duration of the decorated function call."""
+        seed: int = get_new_seed(1, self.torch_rng)  # type: ignore
+
+        def wrapper(*args, **kwargs):
+            with with_tmp_seed(seed):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    def save_state(self) -> dict:
+        """Saves the objective and RNG states to a state dictionary"""
+        obj_dict = {
+            "name": self.__class__.__name__,
+            "seed": self.seed,
+            # numpy bit generator state is nested dictionary with only strings and integers
+            "np_rng": self.np_rng.bit_generator.state,
+            # torch generator state is a tensor so convert it to list for serialization
+            "torch_rng": self.torch_rng.get_state().cpu().tolist(),
+        }
+        return obj_dict
+
+    @classmethod
+    def load_state(cls, obj_dict: dict):
+        """Loads the RNG states from a state dictionary"""
+        instance = cls(seed=obj_dict["seed"])
+        instance.np_rng.bit_generator.state = obj_dict["np_rng"]
+        # must be a ByteTensor
+        instance.torch_rng.set_state(torch.ByteTensor(obj_dict["torch_rng"]))
+        print(
+            "numpy and torch random number generators, and their random states "
+            f"restored with seed {instance.seed}. "
+        )
+        return instance
+
+
+USE_OLD_RNG_CONTROL = False
+
+_GLOBAL_RNG: GlobalRNG | None = None
+
+
+def get_global_rng(seed: int | None = None, verbose: bool = False, reset: bool = False):
+    global _GLOBAL_RNG
+    if _GLOBAL_RNG is None or reset:
+        if reset:
+            print(f"Resetting global RNG with seed {seed}.")
+        # when seed is not provided, a seed will be generated based on the current time
+        _GLOBAL_RNG = GlobalRNG(seed=seed)
+    elif seed and seed != _GLOBAL_RNG.seed:
+        raise ValueError(
+            f"Global RNG has already been initialized with seed {_GLOBAL_RNG.seed}, "
+            f"while a different seed {seed} was provided. "
+            "This is not allowed for statistical integrity considerations. "
+            "To reset all random number generators, please restart the Python session "
+            "or explicitly reinitialize the global RNG through `reset_global_rng`."
+        )
+    else:
+        print(f"Retrieving global RNG initialized with seed {_GLOBAL_RNG.seed}.")
+        if seed and verbose:
+            print(
+                "Global RNG has already been initialized with the same seed "
+                f"{_GLOBAL_RNG.seed}. The current global RNG will be reused. "
+                "If this operation is meant to reset the random state, please reset "
+                "the global RNG explicitly through `reset_global_rng`."
+            )
+    return _GLOBAL_RNG
+
+
+def is_global_rng_initialized() -> bool:
+    """Checks if the global RNG has been initialized."""
+    return _GLOBAL_RNG is not None
+
+
+reset_global_rng = partial(get_global_rng, reset=True)
+
+
+def get_new_seed(num: int, generator: torch.Generator | None = None) -> int | list[int]:
+    """
+    Generates a new random 32-bit integer seed or a list of seeds from a given torch generator.
+
+    Args:
+        num (int): The number of seeds to generate.
+        generator (torch.Generator, optional): The generator to use.
+                                              If None, a new default generator is used.
+
+    Returns:
+        int | list[int]: A new random 32-bit integer seed or a list of seeds.
+    """
+    # The default generator is used if none is provided
+    if generator is None:
+        generator = torch.Generator()
+
+    # Generate a single 32-bit integer seed
+    seed = torch.randint(2**32 - 1, (num,), generator=generator)
+    if num > 1:
+        return seed.tolist()
+    else:
+        return seed.item()  # type: ignore
+
+
+@contextmanager
+def with_tmp_seed(seed: int | None = None):
+    """
+    Context manager to temporarily set and restore global seeds for torch, numpy, and
+    the built-in random module, in case of directly passing a generator to an external
+    method is not possible.
+    """
+    if seed is None:
+        yield
+        return
+
+    # Save original random states
+    original_torch_state = torch.get_rng_state()
+    original_numpy_state = np.random.get_state()
+    original_random_state = random.getstate()
+
+    try:
+        # Set new seeds
+        torch.manual_seed(seed)
+        np.random.seed(seed)
+        random.seed(seed)
+        yield
+    finally:
+        # Restore original random states
+        torch.set_rng_state(original_torch_state)
+        np.random.set_state(original_numpy_state)
+        random.setstate(original_random_state)
+
+
+def dummy_decorator(func):
+    """A dummy decorator for backward compatibility."""
+    return func

--- a/obsidian/rng.py
+++ b/obsidian/rng.py
@@ -1,5 +1,6 @@
 import random
 import time
+import warnings
 from contextlib import contextmanager
 from functools import partial
 
@@ -7,9 +8,10 @@ import numpy as np
 import torch
 
 
-class GlobalRNG:
+class RNGManager:
     """
-    A class to manage global random number generation for reproducibility and statistical integrity.
+    A class to manage random number generation for reproducibility and statistical integrity.
+    Coordinates numpy, torch, and built-in random module states.
     """
 
     def __init__(self, seed: int | None = None):
@@ -26,12 +28,33 @@ class GlobalRNG:
             "Please reuse this seed to reproduce the results."
         )
 
-    def tmp_seed_override(self, func):
-        """Decorator that samples a seed from the global RNG and temporarily overrides the global random states (numpy, torch, random) for the duration of the decorated function call."""
-        seed: int = get_new_seed(1, self.torch_rng)  # type: ignore
-
+    def tmp_seed_override(self, func, manual_seed: int | None = None):
+        """
+        Decorator that temporarily overrides global random states (numpy, torch, random) 
+        for the duration of the decorated function call.
+        
+        Args:
+            func: The function to decorate
+            manual_seed: Optional fixed seed. If provided, the same seed is used for every call.
+                        If None, a new seed is sampled from the RNG for each call.
+        
+        Returns:
+            Wrapped function with temporary seed override
+        """
+        
+        if manual_seed is not None:
+            # Use fixed seed (better numerical stability across multiple calls)
+            get_seed = lambda: manual_seed
+        else:
+            # Sample new seed each call (provides stochastic variation)
+            get_seed = lambda: get_new_seed(1, self.torch_rng)  
+        
         def wrapper(*args, **kwargs):
-            with with_tmp_seed(seed):
+            # Move this inside the wrapper to ensure a new seed is only generated when the function is called
+            # not when the decorator is defined
+            # Note that results from the previous version will not be reproducible
+            seed = get_seed() 
+            with with_tmp_seed(seed): # type: ignore
                 return func(*args, **kwargs)
 
         return wrapper
@@ -55,16 +78,19 @@ class GlobalRNG:
         instance.np_rng.bit_generator.state = obj_dict["np_rng"]
         # must be a ByteTensor
         instance.torch_rng.set_state(torch.ByteTensor(obj_dict["torch_rng"]))
-        print(
-            "numpy and torch random number generators, and their random states "
-            f"restored with seed {instance.seed}. "
-        )
+        print(f"numpy and torch random number generators, and their random states restored with seed {instance.seed}. ")
         return instance
+
+    def spawn_child(self, seed: int | None = None) -> "RNGManager":
+        """Create independent child RNG with derived or explicit seed"""
+        if seed is None:
+            seed = get_new_seed(1, self.torch_rng)  # type: ignore
+        return RNGManager(seed=seed)
 
 
 USE_OLD_RNG_CONTROL = False
 
-_GLOBAL_RNG: GlobalRNG | None = None
+_GLOBAL_RNG: RNGManager | None = None
 
 
 def get_global_rng(seed: int | None = None, verbose: bool = False, reset: bool = False):
@@ -73,14 +99,14 @@ def get_global_rng(seed: int | None = None, verbose: bool = False, reset: bool =
         if reset:
             print(f"Resetting global RNG with seed {seed}.")
         # when seed is not provided, a seed will be generated based on the current time
-        _GLOBAL_RNG = GlobalRNG(seed=seed)
-    elif seed and seed != _GLOBAL_RNG.seed:
-        raise ValueError(
+        _GLOBAL_RNG = RNGManager(seed=seed)
+    elif seed is not None and seed != _GLOBAL_RNG.seed:
+        warnings.warn(
             f"Global RNG has already been initialized with seed {_GLOBAL_RNG.seed}, "
-            f"while a different seed {seed} was provided. "
-            "This is not allowed for statistical integrity considerations. "
-            "To reset all random number generators, please restart the Python session "
-            "or explicitly reinitialize the global RNG through `reset_global_rng`."
+            f"but seed {seed} was requested. Returning existing RNG. "
+            "For independent RNG, create Campaign with explicit seed parameter, "
+            f"or use rng = obsidian.create_rng_manager({seed}).",
+            UserWarning,
         )
     else:
         print(f"Retrieving global RNG initialized with seed {_GLOBAL_RNG.seed}.")
@@ -100,6 +126,35 @@ def is_global_rng_initialized() -> bool:
 
 
 reset_global_rng = partial(get_global_rng, reset=True)
+
+
+def create_rng_manager(seed: int | None = None) -> RNGManager:
+    """
+    Create a new isolated RNG manager instance (not global singleton).
+
+    This is the recommended way to create independent RNGs for multiple campaigns
+    or experiments that should not share random state.
+
+    Args:
+        seed: Explicit seed for the RNG manager, or None to generate from current time
+
+    Returns:
+        New independent RNGManager instance
+    """
+    return RNGManager(seed=seed)
+
+
+def create_torch_rng(seed: int) -> torch.Generator:
+    """
+    Create a torch Generator with given seed.
+    
+    Args:
+        seed (int): The seed for the generator.
+    
+    Returns:
+        torch.Generator: A new generator initialized with the given seed.
+    """
+    return torch.Generator().manual_seed(seed)
 
 
 def get_new_seed(num: int, generator: torch.Generator | None = None) -> int | list[int]:
@@ -155,6 +210,6 @@ def with_tmp_seed(seed: int | None = None):
         random.setstate(original_random_state)
 
 
-def dummy_decorator(func):
+def dummy_decorator(func, manual_seed: int | None = None):
     """A dummy decorator for backward compatibility."""
     return func

--- a/obsidian/surrogates/base.py
+++ b/obsidian/surrogates/base.py
@@ -1,5 +1,6 @@
 """Surrogate model class definition"""
 
+import obsidian
 from obsidian.config import TORCH_DTYPE
 
 from abc import ABC, abstractmethod
@@ -46,7 +47,8 @@ class SurrogateModel(ABC):
 
         # Handle randomization seed, considering all 3 sources (torch, random, numpy)
         self.seed = seed
-        if self.seed is not None:
+        # TODO: this part is only for backward compatibility, we should drop it eventually
+        if self.seed is not None and obsidian.USE_OLD_RNG_CONTROL:
             torch.manual_seed(self.seed)
             torch.use_deterministic_algorithms(True)
             np.random.seed(self.seed)

--- a/obsidian/surrogates/botorch.py
+++ b/obsidian/surrogates/botorch.py
@@ -1,5 +1,6 @@
 """Surrogate models built using BoTorch API and torch_model objects"""
 
+from typing import Callable
 from .base import SurrogateModel
 from .config import model_class_dict
 from .utils import fit_pytorch
@@ -13,7 +14,6 @@ from botorch.optim.fit import fit_gpytorch_mll_torch, fit_gpytorch_mll_scipy
 from botorch.models.gpytorch import GPyTorchModel
 from botorch.models.ensemble import EnsembleModel
 from gpytorch.mlls import ExactMarginalLogLikelihood
-from gpytorch.priors import GammaPrior
 from botorch.optim.utils import sample_all_priors
 
 import torch
@@ -29,7 +29,7 @@ MAX_ATTEMPTS = 5
 # BoTorch default is False
 MULTI_STARTS = False
 # Whether to sample all parameters from prior or not
-RANDOM_INITIAL_PARAMETERS = False 
+SAMPLE_INITIAL_PARAMETERS = False 
 
 class SurrogateBoTorch(SurrogateModel):
     """
@@ -53,6 +53,7 @@ class SurrogateBoTorch(SurrogateModel):
                 to estimate uncertainty.
               
         hps (dict): Optional surrogate function hyperparameters.
+        sample_initial_parameters (bool): Whether to sample initial parameters from the prior. If hyperparameters are not provided, BoTorch will by default initialize the model with some built-in heuristics. To override this behavior, use ``sample_initial_parameters`` to sample all hyperparameters from priors.
         mll (ExactMarginalLogLikelihood): The marginal log likelihood of the model.
         torch_model (torch.nn.Module): The torch model for the surrogate.
         loss (float): The loss of the model.
@@ -62,20 +63,20 @@ class SurrogateBoTorch(SurrogateModel):
                  model_type: str = 'GP',
                  seed: int | None = None,
                  verbose: bool = False,
+                 sample_initial_parameters: bool = SAMPLE_INITIAL_PARAMETERS,
                  hps: dict = {}):
         
         super().__init__(model_type=model_type, seed=seed, verbose=verbose)
         
         # Optional surrogate function hyperparameters
         self.hps = hps
-                
-        return
-    
+        self.sample_initial_parameters = sample_initial_parameters        
+
     def init_model(self,
                    X: pd.DataFrame,
                    y: pd.Series,
                    cat_dims: list[int],
-                   task_feature: int):
+                   task_feature: int | None = None):
         """
         Instantiates the torch model for the surrogate.
         Cannot be called during __init__ normally as X,y are required
@@ -85,6 +86,7 @@ class SurrogateBoTorch(SurrogateModel):
             X (pd.DataFrame): Input parameters for the training data.
             y (pd.Series): Training data responses.
             cat_dims (list): A list of indices for categorical dimensions in the input data.
+            task_feature (int, optional): The index of the task feature in the input data.
 
         Returns:
             None. Updates surrogate attributes, including self.torch_model.
@@ -119,26 +121,36 @@ class SurrogateBoTorch(SurrogateModel):
             self.torch_model = model_class_dict[self.model_type](train_X=X_p, train_Y=y_p, **self.hps).to(TORCH_DTYPE)
         
         # self.torch_model.likelihood.noise_covar.noise_prior = GammaPrior(1.1, 10.0)
-        if RANDOM_INITIAL_PARAMETERS:
+        if self.sample_initial_parameters:
             sample_all_priors(self.torch_model)
 
-        return
 
-    def fit(self,
+    def fit(
+            self,
             X: pd.DataFrame,
             y: pd.Series,
-            cat_dims=None,
-            task_feature=None):
+            cat_dims: list,
+            task_feature: int | None = None,
+            optimizer: Callable | None = None,
+            max_attempts: int = MAX_ATTEMPTS,
+            multi_starts: bool = MULTI_STARTS,
+            **optimizer_kwargs
+        ) -> None:
         """
         Fits the surrogate model to data
 
         Args:
             X (pd.DataFrame): Input parameters for the training data
             y (pd.Series): Training data responses
-            cat_dims (list, optional): A list of indices for categorical dimensions in the input data. Default is ``None``.
+            cat_dims (list): A list of indices for categorical dimensions in the input data.
+            task_feature (int, optional): The index of the task feature in the input data. Default is ``None``.
+            optimizer (callable, optional): The optimizer to use for fitting the model. Default is ``None`` and chosen dynamically based on model type.
+            max_attempts (int, optional): The maximum number of attempts to fit the model. Default is ``MAX_ATTEMPTS=5``.
+            multi_starts (bool, optional): Whether to run all ``max_attempts`` restarts with different initializations and pick the best model. Default is ``MULTI_STARTS=True``.
+            **optimizer_kwargs: Additional keyword arguments to pass to the optimizer.
 
         Returns:
-            None. Updates the surrogate model attributes, including regressed parameters.
+            None. Updates the surrogate model attributes in-place, including regressed parameters.
         """
      
         # Instantiate self.torch_model
@@ -157,14 +169,14 @@ class SurrogateBoTorch(SurrogateModel):
         
         if isinstance(self.torch_model, GPyTorchModel):
             self.loss_fcn = ExactMarginalLogLikelihood(self.torch_model.likelihood, self.torch_model)
-            if self.model_type == 'DKL':
-                optimizer = fit_gpytorch_mll_torch
-            else:
-                optimizer = fit_gpytorch_mll_scipy
+            if optimizer:
+                if self.model_type == 'DKL':
+                    optimizer = fit_gpytorch_mll_torch
+                else:
+                    optimizer = fit_gpytorch_mll_scipy
 
             try:
-                fit_gpytorch_mll(self.loss_fcn, optimizer=optimizer, max_attempts=MAX_ATTEMPTS, pick_best_of_all_attempts=MULTI_STARTS)
-                # fit_gpytorch_mll(self.loss_fcn, optimizer=optimizer)
+                fit_gpytorch_mll(self.loss_fcn, optimizer=optimizer, max_attempts=max_attempts, pick_best_of_all_attempts=multi_starts, **optimizer_kwargs)
             except Exception:
                 try:
                     fit_gpytorch_mll(self.loss_fcn, optimizer=fit_gpytorch_mll_torch)

--- a/obsidian/surrogates/botorch.py
+++ b/obsidian/surrogates/botorch.py
@@ -13,6 +13,8 @@ from botorch.optim.fit import fit_gpytorch_mll_torch, fit_gpytorch_mll_scipy
 from botorch.models.gpytorch import GPyTorchModel
 from botorch.models.ensemble import EnsembleModel
 from gpytorch.mlls import ExactMarginalLogLikelihood
+from gpytorch.priors import GammaPrior
+from botorch.optim.utils import sample_all_priors
 
 import torch
 import torch.nn as nn
@@ -20,6 +22,14 @@ import numpy as np
 import pandas as pd
 import warnings
 
+# Maximum number of attempts to fit the model 
+# BoTorch default is 5
+MAX_ATTEMPTS = 5  
+# Whether to use multiple restarts for optimization
+# BoTorch default is False
+MULTI_STARTS = False
+# Whether to sample all parameters from prior or not
+RANDOM_INITIAL_PARAMETERS = False 
 
 class SurrogateBoTorch(SurrogateModel):
     """
@@ -107,6 +117,10 @@ class SurrogateBoTorch(SurrogateModel):
                     self.torch_model = model_class_dict[self.model_type](train_X=X_p, train_Y=y_p, **self.hps)
         else:
             self.torch_model = model_class_dict[self.model_type](train_X=X_p, train_Y=y_p, **self.hps).to(TORCH_DTYPE)
+        
+        # self.torch_model.likelihood.noise_covar.noise_prior = GammaPrior(1.1, 10.0)
+        if RANDOM_INITIAL_PARAMETERS:
+            sample_all_priors(self.torch_model)
 
         return
 
@@ -149,7 +163,8 @@ class SurrogateBoTorch(SurrogateModel):
                 optimizer = fit_gpytorch_mll_scipy
 
             try:
-                fit_gpytorch_mll(self.loss_fcn, optimizer=optimizer)
+                fit_gpytorch_mll(self.loss_fcn, optimizer=optimizer, max_attempts=MAX_ATTEMPTS, pick_best_of_all_attempts=MULTI_STARTS)
+                # fit_gpytorch_mll(self.loss_fcn, optimizer=optimizer)
             except Exception:
                 try:
                     fit_gpytorch_mll(self.loss_fcn, optimizer=fit_gpytorch_mll_torch)

--- a/obsidian/surrogates/botorch.py
+++ b/obsidian/surrogates/botorch.py
@@ -169,7 +169,7 @@ class SurrogateBoTorch(SurrogateModel):
         
         if isinstance(self.torch_model, GPyTorchModel):
             self.loss_fcn = ExactMarginalLogLikelihood(self.torch_model.likelihood, self.torch_model)
-            if optimizer:
+            if not optimizer:
                 if self.model_type == 'DKL':
                     optimizer = fit_gpytorch_mll_torch
                 else:

--- a/obsidian/tests/conftest.py
+++ b/obsidian/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Shared pytest fixtures for obsidian tests"""
+
+import pytest
+import obsidian
+
+
+@pytest.fixture(params=[False, True], ids=["new_rng", "old_rng"])
+def rng_mode(request):
+    """
+    Fixture to test both RNG control modes.
+
+    Parametrizes tests to run with both:
+    - new_rng: USE_OLD_RNG_CONTROL = False (default, RNGManager-based)
+    - old_rng: USE_OLD_RNG_CONTROL = True (legacy, direct seeding)
+
+    Automatically resets to default after each test.
+    """
+    original = obsidian.USE_OLD_RNG_CONTROL
+    obsidian.USE_OLD_RNG_CONTROL = request.param
+    yield request.param
+    obsidian.USE_OLD_RNG_CONTROL = original

--- a/obsidian/tests/test_campaign.py
+++ b/obsidian/tests/test_campaign.py
@@ -29,10 +29,10 @@ target_test = [
 @pytest.mark.parametrize('X_space, sim_fcn, target',
                          [(X_sp_cont_ndims[2], two_leaves, target_test[0]),
                           (X_sp_default, shifted_parab, target_test[1])])
-def test_campaign_basics(X_space, sim_fcn, target):
+def test_campaign_basics(X_space, sim_fcn, target, rng_mode):
     # Standard usage
-    campaign = Campaign(X_space, target)
-    simulator = Simulator(X_space, sim_fcn, eps=0.05)
+    campaign = Campaign(X_space, target, seed=114514)
+    simulator = Simulator(X_space, sim_fcn, eps=0.05, rng=114514)
     X0 = campaign.suggest()
     y0 = simulator.simulate(X0)
     Z0 = pd.concat([X0, y0], axis=1)
@@ -67,6 +67,9 @@ def test_campaign_basics(X_space, sim_fcn, target):
 # Load default
 with open(DEFAULT_MOO_PATH) as json_file:
     obj_dict = json.load(json_file)
+    # Override seeds for determinism with new RNG control
+    obj_dict['seed'] = 114514
+    obj_dict['optimizer']['opt_attrs']['seed'] = 114514
 campaign = Campaign.load_state(obj_dict)
 X_space = campaign.X_space
 target = campaign.target
@@ -76,6 +79,9 @@ def test_explain():
     # SOO includes discrete variables
     with open(DEFAULT_SOO_PATH) as json_file:
         obj_dict = json.load(json_file)
+        # Override seeds for determinism with new RNG control
+        obj_dict['seed'] = 114514
+        obj_dict['optimizer']['opt_attrs']['seed'] = 114514
     campaign = Campaign.load_state(obj_dict)
     
     # Standard usage

--- a/obsidian/tests/test_constraints.py
+++ b/obsidian/tests/test_constraints.py
@@ -16,6 +16,9 @@ import json
 # Load defaults
 with open(DEFAULT_MOO_PATH) as json_file:
     obj_dict = json.load(json_file)
+    # Override seeds for determinism with new RNG control
+    obj_dict['seed'] = 114514
+    obj_dict['optimizer']['opt_attrs']['seed'] = 114514
 campaign = Campaign.load_state(obj_dict)
 
 optimizer = campaign.optimizer

--- a/obsidian/tests/test_objectives.py
+++ b/obsidian/tests/test_objectives.py
@@ -22,9 +22,12 @@ import pandas as pd
 import pytest
 import json
 
-# Load default
+# Load default campaign
 with open(DEFAULT_MOO_PATH) as json_file:
     obj_dict = json.load(json_file)
+    # Override seeds for determinism with new RNG control
+    obj_dict['seed'] = 114514
+    obj_dict['optimizer']['opt_attrs']['seed'] = 114514
 campaign = Campaign.load_state(obj_dict)
 X_space = campaign.X_space
 target = campaign.target
@@ -64,6 +67,8 @@ def test_campaign_objectives(obj):
 
     # Serialize, deserialize, re-serialize
     obj_dict = campaign.save_state()
+    obj_dict['seed'] = 114514
+    obj_dict['optimizer']['opt_attrs']['seed'] = 114514
     campaign2 = Campaign.load_state(obj_dict)
     obj_dict2 = campaign2.save_state()
     assert equal_state_dicts(obj_dict, obj_dict2), 'Error during serialization'

--- a/obsidian/tests/test_optimizer_MOO.py
+++ b/obsidian/tests/test_optimizer_MOO.py
@@ -24,7 +24,7 @@ def X_space():
 def Z0(X_space):
     designer = ExpDesigner(X_space, seed=0)
     X0 = designer.initialize(m_initial=len(X_space)*2, method='LHS')
-    simulator = Simulator(X_space, two_leaves, eps=0.05)
+    simulator = Simulator(X_space, two_leaves, eps=0.05, rng=0)
     y0 = simulator.simulate(X0)
     Z0 = pd.concat([X0, y0], axis=1)
     return Z0
@@ -71,7 +71,7 @@ base_X_space = X_sp_cont_ndims[2]
 optimizer = BayesianOptimizer(base_X_space, surrogate='GP', seed=0, verbose=0)
 designer = ExpDesigner(base_X_space, seed=0)
 X0 = designer.initialize(m_initial=6, method='LHS')
-simulator = Simulator(base_X_space, two_leaves, eps=0.05)
+simulator = Simulator(base_X_space, two_leaves, eps=0.05, rng=0)
 y0 = simulator.simulate(X0)
 Z0_base = pd.concat([X0, y0], axis=1)
 optimizer.fit(Z0_base, target=target)

--- a/obsidian/tests/test_optimizer_SOO.py
+++ b/obsidian/tests/test_optimizer_SOO.py
@@ -25,7 +25,7 @@ def X_space(request):
 def Z0(X_space):
     designer = ExpDesigner(X_space, seed=1)
     X0 = designer.initialize(m_initial=len(X_space)*2, method='LHS')
-    simulator = Simulator(X_space, shifted_parab, eps=0.05)
+    simulator = Simulator(X_space, shifted_parab, eps=0.05, rng=1)
     y0 = simulator.simulate(X0)
     Z0 = pd.concat([X0, y0], axis=1)
     return Z0
@@ -97,7 +97,7 @@ base_X_space = X_sp_default
 optimizer = BayesianOptimizer(base_X_space, surrogate='GP', seed=0, verbose=0)
 designer = ExpDesigner(base_X_space, seed=0)
 X0 = designer.initialize(m_initial=6, method='LHS')
-simulator = Simulator(base_X_space, shifted_parab, eps=0.05)
+simulator = Simulator(base_X_space, shifted_parab, eps=0.05, rng=0)
 y0 = simulator.simulate(X0)
 Z0_base = pd.concat([X0, y0], axis=1)
 optimizer.fit(Z0_base, target=target)

--- a/obsidian/tests/test_plotting.py
+++ b/obsidian/tests/test_plotting.py
@@ -22,6 +22,9 @@ matplotlib.use('inline')
 
 with open(DEFAULT_MOO_PATH) as json_file:
     obj_dict = json.load(json_file)
+    # Override seeds for determinism with new RNG control
+    obj_dict['seed'] = 114514
+    obj_dict['optimizer']['opt_attrs']['seed'] = 114514
 
 campaign = Campaign.load_state(obj_dict)
 optimizer = campaign.optimizer

--- a/obsidian/tests/test_rng.py
+++ b/obsidian/tests/test_rng.py
@@ -21,7 +21,7 @@ def setup_campaign():
     """Set up a basic campaign for testing"""
     X_space = X_sp_default
     target = Target(name="Response", f_transform="Standard", aim="max")
-    simulator = Simulator(X_space, shifted_parab, eps=0.05, rng=42)
+    simulator = Simulator(X_space, shifted_parab, eps=0.05, rng=114514)
 
     return X_space, target, simulator
 

--- a/obsidian/tests/test_rng.py
+++ b/obsidian/tests/test_rng.py
@@ -74,7 +74,7 @@ def test_global_rng_operations():
     global_rng3 = obsidian.rng.get_global_rng()
     assert global_rng3.seed == 12345
     # Should be a new instance
-    assert global_rng3 is not global_rng1  
+    assert global_rng3 is not global_rng1
 
     # Test that reset changes the RNG behavior
     obsidian.rng.reset_global_rng(seed=100)
@@ -382,9 +382,9 @@ def test_optimizer_rng_save_load(setup_campaign):
     opt_state = optimizer1.save_state()
 
     # Verify RNG state is saved
-    assert 'rng_state' in opt_state
-    assert opt_state['rng_state']['seed'] == 777
-    assert opt_state['fix_random_state'] is True
+    assert "rng_state" in opt_state
+    assert opt_state["rng_state"]["seed"] == 777
+    assert opt_state["fix_random_state"] is True
 
     # Make a suggestion
     X_suggest1, _ = optimizer1.suggest(m_batch=2, acquisition=["EI"])
@@ -394,7 +394,7 @@ def test_optimizer_rng_save_load(setup_campaign):
 
     # Verify RNG attributes are restored
     assert optimizer2.seed == 777
-    assert hasattr(optimizer2, 'rng')
+    assert hasattr(optimizer2, "rng")
     assert optimizer2.rng.seed == 777
 
     # Make suggestion from loaded optimizer - should be deterministic
@@ -408,12 +408,12 @@ def test_optimizer_rng_save_load(setup_campaign):
     optimizer3.fit(Z0, target)
 
     opt_state3 = optimizer3.save_state()
-    assert opt_state3['fix_random_state'] is False
-    assert 'model_generator_state' in opt_state3  # Should save generator state
+    assert opt_state3["fix_random_state"] is False
+    assert "model_generator_state" in opt_state3  # Should save generator state
 
     # Load and verify model_generator is restored
     optimizer4 = BayesianOptimizer.load_state(opt_state3)
-    assert hasattr(optimizer4, 'model_generator')
+    assert hasattr(optimizer4, "model_generator")
     assert optimizer4.model_generator is not None
 
 

--- a/obsidian/tests/test_rng.py
+++ b/obsidian/tests/test_rng.py
@@ -1,0 +1,461 @@
+"""PyTests for RNG control mechanisms"""
+
+import pytest
+import numpy as np
+from obsidian.experiment import ExpDesigner
+import pandas as pd
+import torch
+import obsidian
+from obsidian import create_rng_manager
+from obsidian.rng import RNGManager
+from obsidian.parameters import Target
+from obsidian.campaign import Campaign
+from obsidian.optimizer import BayesianOptimizer
+from obsidian.experiment import Simulator
+from obsidian.experiment.benchmark import shifted_parab
+from obsidian.tests.param_configs import X_sp_default
+
+
+@pytest.fixture
+def setup_campaign():
+    """Set up a basic campaign for testing"""
+    X_space = X_sp_default
+    target = Target(name="Response", f_transform="Standard", aim="max")
+    simulator = Simulator(X_space, shifted_parab, eps=0.05, rng=42)
+
+    return X_space, target, simulator
+
+
+def test_create_new_rng():
+    """Test 1: Create new RNG manager with various inputs"""
+    # Create with seed
+    rng1 = create_rng_manager(42)
+    assert isinstance(rng1, RNGManager)
+    assert rng1.seed == 42
+
+    # Create without seed (random)
+    rng2 = create_rng_manager(None)
+    assert isinstance(rng2, RNGManager)
+    assert rng2.seed is not None
+
+    # Create with explicit seed
+    rng3 = create_rng_manager(123)
+    assert rng3.seed == 123
+
+    # Two RNGs with same seed should produce same random numbers
+    rng_a = create_rng_manager(999)
+    rng_b = create_rng_manager(999)
+
+    val_a = rng_a.np_rng.random(10)
+    val_b = rng_b.np_rng.random(10)
+    assert np.allclose(val_a, val_b)
+
+    # Different seeds should produce different random numbers
+    rng_c = create_rng_manager(111)
+    rng_d = create_rng_manager(222)
+
+    val_c = rng_c.np_rng.random(10)
+    val_d = rng_d.np_rng.random(10)
+    assert not np.allclose(val_c, val_d)
+
+
+def test_global_rng_operations():
+    """Test 2: Global RNG creation, retrieve, reset operations"""
+    # Test get_global_rng creates a new one if doesn't exist
+    global_rng1 = obsidian.rng.get_global_rng()
+    assert isinstance(global_rng1, RNGManager)
+
+    # Retrieving again should return the same instance
+    global_rng2 = obsidian.rng.get_global_rng()
+    assert global_rng1 is global_rng2
+
+    # Reset global RNG
+    obsidian.rng.reset_global_rng(seed=12345)
+    global_rng3 = obsidian.rng.get_global_rng()
+    assert global_rng3.seed == 12345
+    # Should be a new instance
+    assert global_rng3 is not global_rng1  
+
+    # Test that reset changes the RNG behavior
+    obsidian.rng.reset_global_rng(seed=100)
+    rng_a = obsidian.rng.get_global_rng()
+    val1 = rng_a.np_rng.random(5)
+
+    obsidian.rng.reset_global_rng(seed=100)
+    rng_b = obsidian.rng.get_global_rng()
+    val2 = rng_b.np_rng.random(5)
+
+    assert np.allclose(val1, val2)
+
+
+def test_campaign_suggest_consistency(setup_campaign):
+    """Test 3: Campaign suggest gives consistent results with deterministic acquisition (EI)"""
+    X_space, target, simulator = setup_campaign
+
+    # Create two campaigns with same seed
+    campaign1 = Campaign(X_space, target, seed=114514)
+    campaign2 = Campaign(X_space, target, seed=114514)
+
+    # Initialize and fit both campaigns with same data
+    X0 = campaign1.initialize(m_initial=5, method="LHS")
+    y0 = simulator.simulate(X0)
+    Z0 = pd.concat([X0, y0], axis=1)
+
+    campaign1.add_data(Z0)
+    campaign2.add_data(Z0)
+
+    campaign1.fit()
+    campaign2.fit()
+
+    # Suggest with EI (deterministic acquisition function)
+    X_suggest1, _ = campaign1.suggest(m_batch=3, acquisition=["EI"])
+    X_suggest2, _ = campaign2.suggest(m_batch=3, acquisition=["EI"])
+
+    # Results should be identical
+    pd.testing.assert_frame_equal(X_suggest1, X_suggest2)
+
+
+def test_manual_seed_override(setup_campaign):
+    """Test 4: Manual seed override in suggest gives different results"""
+    X_space, target, simulator = setup_campaign
+
+    # Create campaign
+    campaign = Campaign(X_space, target, seed=114514)
+
+    # Initialize and fit
+    X0 = campaign.initialize(m_initial=5, method="LHS")
+    y0 = simulator.simulate(X0)
+    Z0 = pd.concat([X0, y0], axis=1)
+    campaign.add_data(Z0)
+    campaign.fit()
+
+    # Suggest with default seed
+    X_suggest1, _ = campaign.suggest(m_batch=3, acquisition=["EI"])
+
+    # Re-fit to reset state
+    campaign.fit()
+
+    # Suggest with manual seed override
+    X_suggest2, _ = campaign.suggest(m_batch=3, acquisition=["EI"], manual_seed=999)
+
+    # Results should be different due to manual seed override
+    # (Different random restarts in optimization)
+    try:
+        pd.testing.assert_frame_equal(X_suggest1, X_suggest2)
+        # If they're equal, that's suspicious but not necessarily wrong
+        # The manual_seed affects optimization restarts, which may or may not
+        # find different optima depending on the landscape
+    except AssertionError:
+        # Expected: manual_seed changes optimization behavior
+        pass
+
+
+def test_fix_random_state(setup_campaign):
+    """Test 5: fix_random_state works as intended"""
+    X_space, target, simulator = setup_campaign
+
+    designer = ExpDesigner(X_space, seed=114514)
+
+    # Create optimizer with fix_random_state=True (default)
+    opt_fixed = BayesianOptimizer(X_space, seed=114514, fix_random_state=True)
+
+    # Create optimizer with fix_random_state=False
+    opt_not_fixed = BayesianOptimizer(X_space, seed=114514, fix_random_state=False)
+
+    # Generate data
+    X0 = designer.initialize(m_initial=5, method="LHS")
+    y0 = simulator.simulate(X0)
+    Z0 = pd.concat([X0, y0], axis=1)
+
+    # Fit both optimizers
+    opt_fixed.fit(Z0, target)
+    opt_not_fixed.fit(Z0, target)
+
+    # With fix_random_state=True, multiple fits should give identical models
+    opt_fixed_2 = BayesianOptimizer(X_space, seed=114514, fix_random_state=True)
+    opt_fixed_2.fit(Z0, target)
+
+    # Check that model parameters are identical
+    # Both should have deterministic model_generator
+    assert opt_fixed.model_generator is None
+    assert opt_fixed_2.model_generator is None
+
+    # Predictions should be identical
+    X_test = designer.initialize(m_initial=3, method="LHS")
+    pred1 = opt_fixed.predict(X_test)
+    pred2 = opt_fixed_2.predict(X_test)
+    pd.testing.assert_frame_equal(pred1, pred2)
+
+    # With fix_random_state=False, model_generator should exist
+    assert opt_not_fixed.model_generator is not None
+
+
+def test_campaign_save_load_rng_state(setup_campaign):
+    """Test 6: Campaign and optimizer save and load preserve RNG state"""
+    X_space, target, simulator = setup_campaign
+
+    # Create campaign with specific seed
+    campaign1 = Campaign(X_space, target, seed=12345)
+
+    # Initialize, add data, and fit
+    X0 = campaign1.initialize(m_initial=5, method="LHS")
+    y0 = simulator.simulate(X0)
+    Z0 = pd.concat([X0, y0], axis=1)
+    campaign1.add_data(Z0)
+    campaign1.fit()
+
+    # Make a suggestion
+    X_suggest1, _ = campaign1.suggest(m_batch=2, acquisition=["EI"])
+
+    # Save state
+    state = campaign1.save_state()
+
+    # Load into new campaign
+    campaign2 = Campaign.load_state(state)
+
+    # RNG state should be preserved
+    assert campaign2.seed == 12345
+    assert hasattr(campaign2, "rng")
+    assert campaign2.rng.seed == 12345
+
+    # Make another suggestion - should continue from saved RNG state
+    X_suggest2, _ = campaign2.suggest(m_batch=2, acquisition=["EI"])
+
+    # Both campaigns should have the same optimizer state
+    assert campaign1.optimizer.is_fit == campaign2.optimizer.is_fit
+
+    # Test optimizer save/load specifically
+    opt_state = campaign1.optimizer.save_state()
+    opt_loaded = BayesianOptimizer.load_state(opt_state)
+
+    # Check RNG state is preserved in optimizer
+    if "rng_state" in opt_state:
+        assert opt_loaded.seed == campaign1.optimizer.seed
+        assert hasattr(opt_loaded, "rng")
+
+
+def test_old_rng_control_mode(setup_campaign):
+    """Test 7: Test obsidian.USE_OLD_RNG_CONTROL works"""
+    X_space, target, simulator = setup_campaign
+
+    # Save current state
+    original_mode = obsidian.USE_OLD_RNG_CONTROL
+
+    try:
+        # Test with old RNG control (no RNGManager)
+        obsidian.USE_OLD_RNG_CONTROL = True
+
+        # Create campaign - should work without RNGManager
+        campaign_old = Campaign(X_space, target, seed=114514)
+
+        # Should not have RNGManager in old mode
+        assert not hasattr(campaign_old, "rng") or campaign_old.rng is None
+
+        # Initialize and fit should still work
+        X0 = campaign_old.initialize(m_initial=5, method="LHS")
+        y0 = simulator.simulate(X0)
+        Z0 = pd.concat([X0, y0], axis=1)
+        campaign_old.add_data(Z0)
+        campaign_old.fit()
+
+        # Suggest should still work
+        X_suggest_old, _ = campaign_old.suggest(m_batch=2)
+        assert len(X_suggest_old) == 2
+
+        # Test with new RNG control
+        obsidian.USE_OLD_RNG_CONTROL = False
+
+        campaign_new = Campaign(X_space, target, seed=114514)
+
+        # Should have RNGManager in new mode
+        assert hasattr(campaign_new, "rng")
+        assert isinstance(campaign_new.rng, RNGManager)
+
+        # Initialize and fit
+        X0_new = campaign_new.initialize(m_initial=5, method="LHS")
+        y0_new = simulator.simulate(X0_new)
+        Z0_new = pd.concat([X0_new, y0_new], axis=1)
+        campaign_new.add_data(Z0_new)
+        campaign_new.fit()
+
+        # Suggest should work
+        X_suggest_new, _ = campaign_new.suggest(m_batch=2)
+        assert len(X_suggest_new) == 2
+
+    finally:
+        # Restore original mode
+        obsidian.USE_OLD_RNG_CONTROL = original_mode
+
+
+def test_rng_state_save_load():
+    """Test RNGManager state save/load"""
+    # Create RNG with seed
+    rng1 = create_rng_manager(777)
+
+    # Generate some random numbers to advance state
+    rng1.np_rng.random(10)
+    torch.rand(5, generator=rng1.torch_rng)
+
+    # Save state
+    state = rng1.save_state()
+
+    # Generate more numbers
+    val1_np = rng1.np_rng.random(5)
+    val1_torch = torch.rand(3, generator=rng1.torch_rng)
+
+    # Load state into new RNG
+    rng2 = RNGManager.load_state(state)
+
+    # Should produce same numbers as rng1 did after state was saved
+    val2_np = rng2.np_rng.random(5)
+    val2_torch = torch.rand(3, generator=rng2.torch_rng)
+
+    assert np.allclose(val1_np, val2_np)
+    assert torch.allclose(val1_torch, val2_torch)
+
+
+def test_simulator_rng_consistency():
+    """Test that Simulator uses RNG correctly for reproducible noise"""
+    X_space = X_sp_default
+
+    # Create two simulators with same RNG seed
+    sim1 = Simulator(X_space, shifted_parab, eps=0.1, rng=555)
+    sim2 = Simulator(X_space, shifted_parab, eps=0.1, rng=555)
+
+    # Generate same test points
+    X_test = pd.DataFrame(
+        {
+            "Parameter 1": [5.0, 7.5, 2.5],
+            "Parameter 2": [-10.0, -5.0, -15.0],
+            "Parameter 3": [5.0, 5.0, 5.0],
+            "Parameter 7": ["A", "B", "C"],
+        }
+    )
+
+    # Simulate - should get identical results (including noise)
+    y1 = sim1.simulate(X_test)
+    y2 = sim2.simulate(X_test)
+
+    pd.testing.assert_frame_equal(y1, y2)
+
+    # Different seeds should give different noise
+    sim3 = Simulator(X_space, shifted_parab, eps=0.1, rng=999)
+    y3 = sim3.simulate(X_test)
+
+    # Results should differ due to different noise
+    with pytest.raises(AssertionError):
+        pd.testing.assert_frame_equal(y1, y3)
+
+
+def test_shared_rng_flag(setup_campaign):
+    """Test sharing RNG between campaign and optimizer"""
+    X_space, target, _ = setup_campaign
+
+    # Create shared RNG
+    shared_rng = create_rng_manager(42)
+
+    # Create optimizer with shared RNG
+    optimizer = BayesianOptimizer(X_space, rng=shared_rng)
+
+    # Creating campaign with shared RNG should produce warning
+    campaign = Campaign(X_space, target, optimizer=optimizer, rng=shared_rng)
+    assert campaign.rng is optimizer.rng
+    assert campaign._owns_rng is False
+
+
+def test_optimizer_rng_save_load(setup_campaign):
+    """Test that optimizer RNG state is properly saved and restored"""
+    X_space, target, simulator = setup_campaign
+
+    # Create optimizer with specific seed
+    optimizer1 = BayesianOptimizer(X_space, seed=777, fix_random_state=True)
+
+    # Generate and fit data
+    designer = ExpDesigner(X_space, seed=777)
+    X0 = designer.initialize(m_initial=5, method="LHS")
+    y0 = simulator.simulate(X0)
+    Z0 = pd.concat([X0, y0], axis=1)
+
+    optimizer1.fit(Z0, target)
+
+    # Save optimizer state
+    opt_state = optimizer1.save_state()
+
+    # Verify RNG state is saved
+    assert 'rng_state' in opt_state
+    assert opt_state['rng_state']['seed'] == 777
+    assert opt_state['fix_random_state'] is True
+
+    # Make a suggestion
+    X_suggest1, _ = optimizer1.suggest(m_batch=2, acquisition=["EI"])
+
+    # Load optimizer from saved state
+    optimizer2 = BayesianOptimizer.load_state(opt_state)
+
+    # Verify RNG attributes are restored
+    assert optimizer2.seed == 777
+    assert hasattr(optimizer2, 'rng')
+    assert optimizer2.rng.seed == 777
+
+    # Make suggestion from loaded optimizer - should be deterministic
+    X_suggest2, _ = optimizer2.suggest(m_batch=2, acquisition=["EI"])
+
+    # With fix_random_state=True, both should give same results
+    pd.testing.assert_frame_equal(X_suggest1, X_suggest2)
+
+    # Test with fix_random_state=False
+    optimizer3 = BayesianOptimizer(X_space, seed=888, fix_random_state=False)
+    optimizer3.fit(Z0, target)
+
+    opt_state3 = optimizer3.save_state()
+    assert opt_state3['fix_random_state'] is False
+    assert 'model_generator_state' in opt_state3  # Should save generator state
+
+    # Load and verify model_generator is restored
+    optimizer4 = BayesianOptimizer.load_state(opt_state3)
+    assert hasattr(optimizer4, 'model_generator')
+    assert optimizer4.model_generator is not None
+
+
+def test_rng_reproducibility_full_workflow(setup_campaign):
+    """Integration test: Full workflow should be reproducible with same seed"""
+    X_space, target, _ = setup_campaign
+
+    def run_campaign(seed):
+        # Create simulator with fixed seed
+        sim = Simulator(X_space, shifted_parab, eps=0.05, rng=seed)
+
+        # Create campaign
+        campaign = Campaign(X_space, target, seed=seed)
+
+        # Initialize
+        X0 = campaign.initialize(m_initial=5, method="LHS")
+        y0 = sim.simulate(X0)
+        Z0 = pd.concat([X0, y0], axis=1)
+
+        # Add data and fit
+        campaign.add_data(Z0)
+        campaign.fit()
+
+        # Suggest
+        X_suggest, eval_suggest = campaign.suggest(m_batch=3, acquisition=["EI"])
+
+        return X0, y0, X_suggest, eval_suggest
+
+    # Run twice with same seed
+    X0_a, y0_a, X_suggest_a, eval_suggest_a = run_campaign(12345)
+    X0_b, y0_b, X_suggest_b, eval_suggest_b = run_campaign(12345)
+
+    # Everything should be identical
+    pd.testing.assert_frame_equal(X0_a, X0_b)
+    pd.testing.assert_frame_equal(y0_a, y0_b)
+    pd.testing.assert_frame_equal(X_suggest_a, X_suggest_b)
+    # eval_suggest may have small numerical differences in predictions
+    # so we test with tolerance
+    for col in eval_suggest_a.columns:
+        if eval_suggest_a[col].dtype in [np.float64, np.float32]:
+            assert np.allclose(eval_suggest_a[col].values, eval_suggest_b[col].values, rtol=1e-5, atol=1e-8)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,5 @@ filterwarnings =
     ignore::linear_operator.utils.warnings.NumericalWarning
     ignore::gpytorch.utils.warnings.GPInputWarning
     ignore::UserWarning
+    ignore::DeprecationWarning
+    ignore::FutureWarning


### PR DESCRIPTION
This PR addresses random state management issues in #80 to improve reproducibility.

## Implementation

- **RNGManager class**: Centralized wrapper managing NumPy and PyTorch generators with synchronized seeding
- **Single seed per campaign**: One seed initialization ensures consistent randomness throughout campaign lifecycle
- **Explicit RNG passing**: Components (Campaign, Optimizer, ExpDesigner, Simulator) accept RNG instances explicitly instead of global state resets
- **State persistence**: Campaign and Optimizer save/load complete RNG state (seed + generator states) 
- **Ownership tracking**: `_owns_rng` flag distinguishes owned vs shared RNG instances
- **Temporary seed overrides**: Context manager allows `manual_seed` parameter without global pollution
- **Backward compatibility**: `obsidian.USE_OLD_RNG_CONTROL` toggle for legacy behavior
- **Comprehensive testing**: 11 tests covering RNG lifecycle, state persistence, and reproducibility


### Other changes

Some other improvements were made while this new RNG control was implemented.

1. Introduced direct optimizer options passthrough to model fitting routine in campaign.fit. You can now do
    
    ```python
    campaign.fit({"max_attempts": 10, "multi_starts": True})
    ```

    to fit with model with 10 different restarts.
2. Introduced direct optimizer options passthrough to acquisition function optimization in optimizer.suggest
    
    ```python
    campaign.optimizer.suggest(
        ...,
        optim_options={"method": "Powell", "maxiter": 100}
    )
    ```
    
   This will tell `scipy.optimize.minimize` to use `Powell` and maximum iteration of 100.

## Current status

The following tests have been performed, both on single objective (modified from `Simple single objective.ipynb`)

1. The new code, with `obsidian.USE_OLD_RNG_CONTROL=True` produces the same results as the current main branch.
2. With new RNG control, two runs with the same initial random states achieve identical results with categorical parameters.
3. With new RNG control, two runs with the same initial random states achieve identical results without categorical parameters. (fixed in 1064d6f1c58a6f3d032578ff2613ec1788d4fbde).