### PR TITLE
Fix the divided by 0 issue in standard transform 

### DIFF
--- a/obsidian/parameters/transforms.py
+++ b/obsidian/parameters/transforms.py
@@ -84,7 +84,11 @@ class Standard_Scaler(Target_Transform):
             self.params = {'mu': X_v.mean(), 'sd': X_v.std()}
         else:
             self._validate_fit()
-        return (X-self.params['mu'])/self.params['sd']
+        if self.params["sd"] == 0:
+            # In the edge case where `X` is degenerate, avoid 0 divided by 0
+            return zeros_like(X)
+        else:
+            return (X-self.params['mu'])/self.params['sd']
     
     def inverse(self, X):
         """Inverse transform the transformed data X_t"""


### PR DESCRIPTION
A simple fix for #83. There are multiple ways to do it. My propose fix:

Replace the line

```python
    return (X-self.params['mu'])/self.params['sd']
```

to
```
        if self.params["sd"] == 0:
            # In the edge case where `X` is degenerate, avoid 0 divided by 0
            return zeros_like(X)
        else:
            return (X-self.params['mu'])/self.params['sd']
```

BoTorch only complains that `InputDataWarning: Data is not standardized (std = tensor([0.], dtype=torch.float64), mean = tensor([0.], dtype=torch.float64)). Please consider scaling the input to zero mean and unit variance.`, which is understandable.