### PR TITLE
Add campaign copy and fix missing surrogates module at the package level

### DIFF
--- a/obsidian/__init__.py
+++ b/obsidian/__init__.py
@@ -14,3 +14,4 @@ import obsidian.constraints as constraints
 import obsidian.exceptions as exceptions
 import obsidian.acquisition as acquisition
 import obsidian.plotting as plotting
+import obsidian.surrogates as surrogates

--- a/obsidian/campaign/campaign.py
+++ b/obsidian/campaign/campaign.py
@@ -464,3 +464,14 @@ class Campaign():
                 new_campaign.constrain_outputs(const)
 
         return new_campaign
+
+    def copy(self):
+        """
+        Creates a deep copy of the Campaign object.
+
+        A shortcut for saving and then loading the state. The presence of the torch objects prevents a direct deepcopy.
+
+        Returns:
+            Campaign: A deep copy of the Campaign object.
+        """
+        return self.__class__.load_state(self.save_state())


### PR DESCRIPTION
A simple new method was added to `Campaign`

```python
    def copy(self):
        """
        Creates a deep copy of the Campaign object.

        A shortcut for saving and then loading the state. The presence of the torch objects prevents a direct deepcopy.

        Returns:
            Campaign: A deep copy of the Campaign object.
        """
        return self.__class__.load_state(self.save_state())
```

basically just a short hand of save and then load for quick branching of the existing campaign.

`import obsidian.surrogates as surrogates` is added to the package level, so we will not see the following linter issues anymore. The modules works fine without this line, but completion and linting are totally broken.

<img width="588" height="127" alt="image" src="https://github.com/user-attachments/assets/0739a929-df21-4ccf-ac52-c84719c4b626" />
