### PR TITLE
Fix FlatGP and tests

### DIFF
--- a/obsidian/surrogates/custom_GP.py
+++ b/obsidian/surrogates/custom_GP.py
@@ -65,7 +65,13 @@ class FlatGP(ExactGP, GPyTorchModel):
 
     def __init__(self, train_X, train_Y, nu=2.5):
 
-        super().__init__(train_X, train_Y.squeeze(-1), GaussianLikelihood())
+        likelihood = GaussianLikelihood()
+        # Add a safeguard to prevent failures from singular kernel matrix at the initialization step
+        # The default value is softplus(0) + GreaterThan(1e-4) = ln(2) + 1e-4 = 0.6932471805599453
+        # This makes the initial raw noise exactly 0, which can cause non-PSD problems
+        # Anything not exactly ln(2) + 1e-4 will mitigate this issue
+        likelihood.noise = torch.Tensor([0.6932])
+        super().__init__(train_X, train_Y.squeeze(-1), likelihood)
         
         n_dims = train_X.shape[-1]
         

--- a/obsidian/tests/conftest.py
+++ b/obsidian/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Shared pytest fixtures for obsidian tests"""
+
+import pytest
+import torch
+from obsidian.config import TORCH_DTYPE
+
+
+@pytest.fixture(autouse=True)
+def set_default_dtype():
+    torch.set_default_dtype(TORCH_DTYPE)
+    yield


### PR DESCRIPTION
- Prevent FlatGP from failing some tests due to non-PSD issues with double precision
- Add global test configuration enforcing double precision for all tests