### PR TITLE
Acquisition Function Handling & Related Improvements

### DIFF
--- a/obsidian/__init__.py
+++ b/obsidian/__init__.py
@@ -1,11 +1,13 @@
 """obsidian: Automated experiment design and black-box optimization"""
-__version__ = '0.8.6'
+
+__version__ = "0.8.6"
 
 # Import key objects
 from obsidian.campaign import Campaign
 from obsidian.optimizer import BayesianOptimizer
 from obsidian.surrogates import SurrogateBoTorch
 from obsidian.parameters import ParamSpace, Target
+from obsidian.rng import get_global_rng, reset_global_rng, USE_OLD_RNG_CONTROL, is_global_rng_initialized
 
 # Ensure that other subpackages are imported properly for documentation
 from obsidian.objectives import Objective

--- a/obsidian/__init__.py
+++ b/obsidian/__init__.py
@@ -7,7 +7,7 @@ from obsidian.campaign import Campaign
 from obsidian.optimizer import BayesianOptimizer
 from obsidian.surrogates import SurrogateBoTorch
 from obsidian.parameters import ParamSpace, Target
-from obsidian.rng import get_global_rng, reset_global_rng, USE_OLD_RNG_CONTROL, is_global_rng_initialized
+from obsidian.rng import create_rng_manager, USE_OLD_RNG_CONTROL
 
 # Ensure that other subpackages are imported properly for documentation
 from obsidian.objectives import Objective

--- a/obsidian/__init__.py
+++ b/obsidian/__init__.py
@@ -16,3 +16,4 @@ import obsidian.constraints as constraints
 import obsidian.exceptions as exceptions
 import obsidian.acquisition as acquisition
 import obsidian.plotting as plotting
+import obsidian.rng as rng

--- a/obsidian/acquisition/botorch.py
+++ b/obsidian/acquisition/botorch.py
@@ -3,10 +3,12 @@
 # Botorch acquisition functions supported in obsidian
 from botorch.acquisition import qProbabilityOfImprovement, qUpperConfidenceBound, qSimpleRegret
 from botorch.acquisition.logei import qLogExpectedImprovement, qLogNoisyExpectedImprovement
-from botorch.acquisition.multi_objective.logei import qLogExpectedHypervolumeImprovement, qLogNoisyExpectedHypervolumeImprovement
+from botorch.acquisition.multi_objective.logei import (
+    qLogExpectedHypervolumeImprovement,
+    qLogNoisyExpectedHypervolumeImprovement,
+)
 from botorch.acquisition.multi_objective.parego import qLogNParEGO
 from botorch.acquisition.active_learning import qNegIntegratedPosteriorVariance
-
 
 __all__ = [
     "qProbabilityOfImprovement",

--- a/obsidian/acquisition/config.py
+++ b/obsidian/acquisition/config.py
@@ -1,48 +1,149 @@
 """Method pointers and config for acquisition functions"""
 
-from .custom import qMean, qSpaceFill
+from typing import Callable, Dict, Type
+
+# avoid possible naming space collision
+import obsidian.acquisition.utils as acq_utils
 
 from .botorch import (
-    qProbabilityOfImprovement, qUpperConfidenceBound, qSimpleRegret,
-    qLogExpectedImprovement, qLogNoisyExpectedImprovement,
-    qLogExpectedHypervolumeImprovement, qLogNoisyExpectedHypervolumeImprovement,
-    qLogNParEGO, qNegIntegratedPosteriorVariance
+    qLogExpectedHypervolumeImprovement,
+    qLogExpectedImprovement,
+    qLogNoisyExpectedHypervolumeImprovement,
+    qLogNoisyExpectedImprovement,
+    qLogNParEGO,
+    qNegIntegratedPosteriorVariance,
+    qProbabilityOfImprovement,
+    qSimpleRegret,
+    qUpperConfidenceBound,
 )
+from .custom import qMean, qSpaceFill
 
-
-# Available acquisition functions and method pointers
-aq_class_dict = {'EI': qLogExpectedImprovement,
-                 'NEI': qLogNoisyExpectedImprovement,
-                 'PI': qProbabilityOfImprovement,
-                 'UCB': qUpperConfidenceBound,
-                 'SR': qSimpleRegret,
-                 'EHVI': qLogExpectedHypervolumeImprovement,
-                 'NEHVI': qLogNoisyExpectedHypervolumeImprovement,
-                 'NParEGO': qLogNParEGO,
-                 'NIPV': qNegIntegratedPosteriorVariance,
-                 'RS': None,
-                 'Mean': qMean,
-                 'SF': qSpaceFill}
-
-# Acquisition functions separated by optimization modality
-universal_aqs = ['RS', 'Mean', 'SF']
-valid_aqs = {'single': ['EI', 'NEI', 'PI', 'UCB', 'SR', 'NIPV'] + universal_aqs,
-             'multi': ['EHVI', 'NEHVI', 'NParEGO'] + universal_aqs}
-aq_defaults = {'single': 'NEI', 'multi': 'NEHVI'}
-
-
-# For default values, 'optional' indicates whether or not a default value (or None) 'val' can be used
-aq_hp_defaults = {
-    'EI': {'inflate': {'val':  0, 'optional': True}},
-    'NEI': {},
-    'PI': {'inflate': {'val':  0, 'optional': True}},
-    'UCB': {'beta': {'val': 1, 'optional': True}},
-    'SR': {},
-    'RS': {},
-    'Mean': {},
-    'SF': {},
-    'NIPV': {},
-    'EHVI': {'ref_point': {'val': None, 'optional': True}},
-    'NEHVI': {'ref_point': {'val': None, 'optional': True}},
-    'NParEGO': {'scalarization_weights': {'val': None, 'optional': True}},
+_builtin_acq_func_dict = {
+    # Single-objective optimization
+    "EI": {
+        "implementation": qLogExpectedImprovement,
+        "hyperparameter_defaults": {
+            "inflate": {"val": 0, "dtype": float, "optional": True}
+        },
+        "hyperparameter_parser": acq_utils._ei_hyperparameter_parser,
+        "modalities": ["single"],
+    },
+    "NEI": {
+        "implementation": qLogNoisyExpectedImprovement,
+        "hyperparameter_defaults": {},
+        "hyperparameter_parser": acq_utils._noisy_parser,
+        "modalities": ["single"],
+    },
+    "PI": {
+        "implementation": qProbabilityOfImprovement,
+        "hyperparameter_defaults": {"inflate": {"val": 0, "dtype": float, "optional": True}},
+        "hyperparameter_parser": acq_utils._ei_hyperparameter_parser,
+        "modalities": ["single"],
+    },
+    "UCB": {
+        "implementation": qUpperConfidenceBound,
+        "hyperparameter_defaults": {"beta": {"val": 1, "dtype": float, "optional": True}},
+        "hyperparameter_parser": acq_utils._ucb_hyperparameter_parser,
+        "modalities": ["single"],
+    },
+    "SR": {
+        "implementation": qSimpleRegret,
+        "hyperparameter_defaults": {},
+        "hyperparameter_parser": None,
+        "hyperparameter_parser": None,
+        "modalities": ["single"],
+    },
+    "NIPV": {
+        "implementation": qNegIntegratedPosteriorVariance,
+        "hyperparameter_defaults": {},
+        "hyperparameter_parser": acq_utils._nipv_hyperparameter_parser,
+        "modalities": ["single"],
+    },
+    # Multi-objective optimization
+    "EHVI": {
+        "implementation": qLogExpectedHypervolumeImprovement,
+        "hyperparameter_defaults": {"ref_point": {"val": None, "dtype": list, "optional": True}},
+        "hyperparameter_parser": acq_utils._ehvi_hyperparameter_parser,
+        "modalities": ["multi"],
+    },
+    "NEHVI": {
+        "implementation": qLogNoisyExpectedHypervolumeImprovement,
+        "hyperparameter_defaults": {"ref_point": {"val": None, "dtype": list, "optional": True}},
+        "hyperparameter_parser": acq_utils._nehvi_hyperparameter_parser,
+        "modalities": ["multi"],
+    },
+    "NParEGO": {
+        "implementation": qLogNParEGO,
+        "hyperparameter_defaults": {
+            "scalarization_weights": {"val": None, "dtype": list, "optional": True}
+        },
+        "hyperparameter_parser": acq_utils._nparego_hyperparameter_parser,
+        "modalities": ["multi"],
+    },
+    # Universal optimization functions
+    "RS": {
+        "implementation": None,
+        "hyperparameter_defaults": {},
+        "hyperparameter_parser": None,
+        "modalities": ["single", "multi"],
+    },
+    "Mean": {
+        "implementation": qMean,
+        "hyperparameter_defaults": {},
+        "hyperparameter_parser": None,
+        "modalities": ["single", "multi"],
+    },
+    "SF": {
+        "implementation": qSpaceFill,
+        "hyperparameter_defaults": {},
+        "hyperparameter_parser": acq_utils._sf_hyperparameter_parser,
+        "modalities": ["single", "multi"],
+    },
 }
+
+# Create the singleton registry instance
+_registry = acq_utils.AcquisitionRegistry(_builtin_acq_func_dict)
+
+
+# Export the registration function with the same interface
+def acquisition_function_register(
+    name: str,
+    implementation: Type,
+    hp_defaults: Dict | None = None,
+    is_single_target=False,
+    is_multi_target=False,
+    set_as_default=False,
+    overloading=False,
+    internal_parser=False,
+    external_parser: Callable | None = None,
+):
+    """
+    Register a new acquisition function (backward compatibility wrapper).
+
+    This function maintains the original API while using the new registry internally.
+    """
+    _registry.register_acquisition_function(
+        name=name,
+        implementation=implementation,
+        hp_defaults=hp_defaults,
+        is_single_target=is_single_target,
+        is_multi_target=is_multi_target,
+        set_as_default=set_as_default,
+        overloading=overloading,
+        internal_hyperparameter_parser=internal_parser,
+        external_hyperparameter_parser=external_parser,
+    )
+
+
+# Export the registry properties for backward compatibility
+aq_class_dict = _registry.aq_class_dict
+aq_hp_defaults = _registry.aq_hp_defaults
+external_aqs = _registry.external_aqs
+# Note that one nested layer is added for future characterization functions
+# For now, to keep backward compatibility, we flatten the structure
+valid_aqs = _registry.valid_opt_aqs
+aq_defaults = _registry.aq_defaults["optimization"]
+universal_aqs = _registry.universal_aqs
+
+# Export the registry for direct access if needed
+registry = _registry

--- a/obsidian/acquisition/config.py
+++ b/obsidian/acquisition/config.py
@@ -51,7 +51,7 @@ _builtin_acq_func_dict = {
     "SR": {
         "implementation": qSimpleRegret,
         "hyperparameter_defaults": {},
-        "hyperparameter_parser": None,
+        "hyperparameter_parser": acq_utils.dummy_parser,
         "modalities": ["single"],
         "task_types": ["optimization"],
     },
@@ -88,7 +88,7 @@ _builtin_acq_func_dict = {
     "Mean": {
         "implementation": qMean,
         "hyperparameter_defaults": {},
-        "hyperparameter_parser": None,
+        "hyperparameter_parser": acq_utils.dummy_parser,
         "modalities": ["single", "multi"],
         "task_types": ["optimization"],
     },

--- a/obsidian/acquisition/config.py
+++ b/obsidian/acquisition/config.py
@@ -1,6 +1,6 @@
 """Method pointers and config for acquisition functions"""
 
-from typing import Callable, Dict, Type
+from typing import Callable, Type
 
 # avoid possible naming space collision
 import obsidian.acquisition.utils as acq_utils
@@ -16,48 +16,51 @@ from .botorch import (
     qSimpleRegret,
     qUpperConfidenceBound,
 )
-from .custom import qMean, qSpaceFill
+from .custom import qMean, qSpaceFill, RandomSampling
 
 _builtin_acq_func_dict = {
     # Single-objective optimization
     "EI": {
         "implementation": qLogExpectedImprovement,
-        "hyperparameter_defaults": {
-            "inflate": {"val": 0, "dtype": float, "optional": True}
-        },
+        "hyperparameter_defaults": {"inflate": {"val": 0, "dtype": float, "optional": True}},
         "hyperparameter_parser": acq_utils._ei_hyperparameter_parser,
         "modalities": ["single"],
+        "task_types": ["optimization"],
     },
     "NEI": {
         "implementation": qLogNoisyExpectedImprovement,
         "hyperparameter_defaults": {},
         "hyperparameter_parser": acq_utils._noisy_parser,
         "modalities": ["single"],
+        "task_types": ["optimization"],
     },
     "PI": {
         "implementation": qProbabilityOfImprovement,
         "hyperparameter_defaults": {"inflate": {"val": 0, "dtype": float, "optional": True}},
         "hyperparameter_parser": acq_utils._ei_hyperparameter_parser,
         "modalities": ["single"],
+        "task_types": ["optimization"],
     },
     "UCB": {
         "implementation": qUpperConfidenceBound,
         "hyperparameter_defaults": {"beta": {"val": 1, "dtype": float, "optional": True}},
         "hyperparameter_parser": acq_utils._ucb_hyperparameter_parser,
         "modalities": ["single"],
+        "task_types": ["optimization"],
     },
     "SR": {
         "implementation": qSimpleRegret,
         "hyperparameter_defaults": {},
         "hyperparameter_parser": None,
-        "hyperparameter_parser": None,
         "modalities": ["single"],
+        "task_types": ["optimization"],
     },
     "NIPV": {
         "implementation": qNegIntegratedPosteriorVariance,
         "hyperparameter_defaults": {},
         "hyperparameter_parser": acq_utils._nipv_hyperparameter_parser,
         "modalities": ["single"],
+        "task_types": ["optimization"],
     },
     # Multi-objective optimization
     "EHVI": {
@@ -65,39 +68,44 @@ _builtin_acq_func_dict = {
         "hyperparameter_defaults": {"ref_point": {"val": None, "dtype": list, "optional": True}},
         "hyperparameter_parser": acq_utils._ehvi_hyperparameter_parser,
         "modalities": ["multi"],
+        "task_types": ["optimization"],
     },
     "NEHVI": {
         "implementation": qLogNoisyExpectedHypervolumeImprovement,
         "hyperparameter_defaults": {"ref_point": {"val": None, "dtype": list, "optional": True}},
         "hyperparameter_parser": acq_utils._nehvi_hyperparameter_parser,
         "modalities": ["multi"],
+        "task_types": ["optimization"],
     },
     "NParEGO": {
         "implementation": qLogNParEGO,
-        "hyperparameter_defaults": {
-            "scalarization_weights": {"val": None, "dtype": list, "optional": True}
-        },
+        "hyperparameter_defaults": {"scalarization_weights": {"val": None, "dtype": list, "optional": True}},
         "hyperparameter_parser": acq_utils._nparego_hyperparameter_parser,
         "modalities": ["multi"],
+        "task_types": ["optimization"],
     },
-    # Universal optimization functions
-    "RS": {
-        "implementation": None,
-        "hyperparameter_defaults": {},
-        "hyperparameter_parser": None,
-        "modalities": ["single", "multi"],
-    },
+    # Single and multi-objective optimization
     "Mean": {
         "implementation": qMean,
         "hyperparameter_defaults": {},
         "hyperparameter_parser": None,
         "modalities": ["single", "multi"],
+        "task_types": ["optimization"],
+    },
+    # Universal functions
+    "RS": {
+        "implementation": RandomSampling,
+        "hyperparameter_defaults": {},
+        "hyperparameter_parser": RandomSampling.parser,
+        "modalities": ["single", "multi"],
+        "task_types": ["optimization", "characterization"],
     },
     "SF": {
         "implementation": qSpaceFill,
         "hyperparameter_defaults": {},
-        "hyperparameter_parser": acq_utils._sf_hyperparameter_parser,
+        "hyperparameter_parser": qSpaceFill.parser,
         "modalities": ["single", "multi"],
+        "task_types": ["optimization", "characterization"],
     },
 }
 
@@ -109,7 +117,7 @@ _registry = acq_utils.AcquisitionRegistry(_builtin_acq_func_dict)
 def acquisition_function_register(
     name: str,
     implementation: Type,
-    hp_defaults: Dict | None = None,
+    hp_defaults: dict | None = None,
     is_single_target=False,
     is_multi_target=False,
     set_as_default=False,
@@ -142,7 +150,7 @@ external_aqs = _registry.external_aqs
 # Note that one nested layer is added for future characterization functions
 # For now, to keep backward compatibility, we flatten the structure
 valid_aqs = _registry.valid_opt_aqs
-aq_defaults = _registry.aq_defaults["optimization"]
+aq_defaults = _registry.aq_defaults
 universal_aqs = _registry.universal_aqs
 
 # Export the registry for direct access if needed

--- a/obsidian/acquisition/custom.py
+++ b/obsidian/acquisition/custom.py
@@ -1,16 +1,53 @@
 """Custom implementations of acquisition functions using BoTorch API"""
+from typing import Any
 
 from botorch.acquisition.monte_carlo import MCAcquisitionFunction
-from botorch.sampling.normal import SobolQMCNormalSampler
 from botorch.utils import t_batch_mode_transform
 from botorch.acquisition.multi_objective.objective import IdentityMCMultiOutputObjective
 from botorch.models.model import Model
 from botorch.sampling.base import MCSampler
 from botorch.acquisition.objective import MCAcquisitionObjective, PosteriorTransform
 
+from .utils import ParserContext, default_sampler
+from ..config import TORCH_DTYPE
+
 import torch
 from torch import Tensor
 
+class RandomSampling(torch.nn.Module):
+    def __init__(self,
+                 m_batch: int,
+                 n_dim: int,
+                 data_type: torch.dtype = TORCH_DTYPE,
+                 generator: torch.Generator | None = None,
+                 model: Model | None = None,
+                 sampler: MCSampler | None = None,
+                 objective: MCAcquisitionObjective | None = None,
+                 posterior_transform: PosteriorTransform | None = None,
+                 X_pending: Tensor | None = None,
+                 constraints=None,
+                 ):
+
+        self.m_batch = m_batch
+        self.n_dim = n_dim
+        self.data_type = data_type
+        if generator is None:
+            # fallback to stateless behavior uses global RNG
+            self.generator = torch.Generator()
+        else:
+            self.generator = generator
+
+    def forward(self, x: Tensor | None = None) -> torch.Tensor:
+        return torch.rand((self.m_batch, self.n_dim), generator=self.generator, dtype=self.data_type)
+
+    @staticmethod
+    def parser(
+        aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
+    ) -> dict[str, Any]:
+       aq_kwargs["m_batch"] = context["m_batch"]
+       aq_kwargs["n_dim"] = context["n_dim"]
+       aq_kwargs["generator"] = context["generator"]
+       return aq_kwargs
 
 class qMean(MCAcquisitionFunction):
     """
@@ -19,13 +56,10 @@ class qMean(MCAcquisitionFunction):
     """
     def __init__(self,
                  model: Model,
-                 sampler: MCSampler | None = None,
+                 sampler: MCSampler = default_sampler,
                  objective: MCAcquisitionObjective | None = None,
                  posterior_transform: PosteriorTransform | None = None,
                  X_pending: Tensor | None = None):
-        
-        if sampler is None:
-            sampler = SobolQMCNormalSampler(sample_shape=torch.Size([512]))
         
         # An objective is required if this aq is used on a multi-output model
         if objective is None:
@@ -65,13 +99,10 @@ class qSpaceFill(MCAcquisitionFunction):
     def __init__(self,
                  model: Model,
                  X_baseline: Tensor,
-                 sampler: MCSampler | None = None,
+                 sampler: MCSampler = default_sampler,
                  objective: MCAcquisitionObjective | None = None,
                  posterior_transform: PosteriorTransform | None = None,
                  X_pending: Tensor | None = None,):
-        
-        if sampler is None:
-            sampler = SobolQMCNormalSampler(sample_shape=torch.Size([512]))
         
         # An objective is required if this aq is used on a multi-output model
         if model.num_outputs > 1:
@@ -107,3 +138,11 @@ class qSpaceFill(MCAcquisitionFunction):
         closest_dist = dist.min(dim=-1)[0].min(dim=-1)[0]
 
         return closest_dist
+
+    @staticmethod
+    def parser(
+        aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
+    ) -> dict[str, Any]:
+        """Parser for Space Filling acquisition function"""
+        aq_kwargs["X_baseline"] = context["X_baseline"]
+        return aq_kwargs

--- a/obsidian/acquisition/custom.py
+++ b/obsidian/acquisition/custom.py
@@ -1,4 +1,5 @@
 """Custom implementations of acquisition functions using BoTorch API"""
+
 from typing import Any
 
 from botorch.acquisition.monte_carlo import MCAcquisitionFunction
@@ -14,20 +15,22 @@ from ..config import TORCH_DTYPE
 import torch
 from torch import Tensor
 
-class RandomSampling(torch.nn.Module):
-    def __init__(self,
-                 m_batch: int,
-                 n_dim: int,
-                 data_type: torch.dtype = TORCH_DTYPE,
-                 generator: torch.Generator | None = None,
-                 model: Model | None = None,
-                 sampler: MCSampler | None = None,
-                 objective: MCAcquisitionObjective | None = None,
-                 posterior_transform: PosteriorTransform | None = None,
-                 X_pending: Tensor | None = None,
-                 constraints=None,
-                 ):
 
+class RandomSampling(torch.nn.Module):
+    def __init__(
+        self,
+        m_batch: int,
+        n_dim: int,
+        data_type: torch.dtype = TORCH_DTYPE,
+        generator: torch.Generator | None = None,
+        model: Model | None = None,
+        sampler: MCSampler | None = None,
+        objective: MCAcquisitionObjective | None = None,
+        posterior_transform: PosteriorTransform | None = None,
+        X_pending: Tensor | None = None,
+        constraints=None,
+    ):
+        super().__init__()
         self.m_batch = m_batch
         self.n_dim = n_dim
         self.data_type = data_type
@@ -41,26 +44,28 @@ class RandomSampling(torch.nn.Module):
         return torch.rand((self.m_batch, self.n_dim), generator=self.generator, dtype=self.data_type)
 
     @staticmethod
-    def parser(
-        aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
-    ) -> dict[str, Any]:
-       aq_kwargs["m_batch"] = context["m_batch"]
-       aq_kwargs["n_dim"] = context["n_dim"]
-       aq_kwargs["generator"] = context["generator"]
-       return aq_kwargs
+    def parser(aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext) -> dict[str, Any]:
+        aq_kwargs["m_batch"] = context["m_batch"]
+        aq_kwargs["n_dim"] = context["n_dim"]
+        aq_kwargs["generator"] = context["generator"]
+        return aq_kwargs
+
 
 class qMean(MCAcquisitionFunction):
     """
     Acquisition function which optimizes for the
     maximum value of the posterior mean
     """
-    def __init__(self,
-                 model: Model,
-                 sampler: MCSampler = default_sampler,
-                 objective: MCAcquisitionObjective | None = None,
-                 posterior_transform: PosteriorTransform | None = None,
-                 X_pending: Tensor | None = None):
-        
+
+    def __init__(
+        self,
+        model: Model,
+        sampler: MCSampler = default_sampler,
+        objective: MCAcquisitionObjective | None = None,
+        posterior_transform: PosteriorTransform | None = None,
+        X_pending: Tensor | None = None,
+    ):
+
         # An objective is required if this aq is used on a multi-output model
         if objective is None:
             if model.num_outputs > 1:
@@ -68,12 +73,16 @@ class qMean(MCAcquisitionFunction):
             else:
                 objective = None  # This will be set to identity in super call
 
-        super().__init__(model=model, sampler=sampler, objective=objective,
-                         posterior_transform=posterior_transform, X_pending=X_pending)
+        super().__init__(
+            model=model,
+            sampler=sampler,
+            objective=objective,
+            posterior_transform=posterior_transform,
+            X_pending=X_pending,
+        )
 
     @t_batch_mode_transform()
-    def forward(self,
-                x: Tensor) -> Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         """
         Evaluate the acquisition function on the candidate set x
         """
@@ -96,53 +105,58 @@ class qSpaceFill(MCAcquisitionFunction):
     Acquisition function which optimizes for the
     maximum value of minimum distance between a point and the training data
     """
-    def __init__(self,
-                 model: Model,
-                 X_baseline: Tensor,
-                 sampler: MCSampler = default_sampler,
-                 objective: MCAcquisitionObjective | None = None,
-                 posterior_transform: PosteriorTransform | None = None,
-                 X_pending: Tensor | None = None,):
-        
+
+    def __init__(
+        self,
+        model: Model,
+        X_baseline: Tensor,
+        sampler: MCSampler = default_sampler,
+        objective: MCAcquisitionObjective | None = None,
+        posterior_transform: PosteriorTransform | None = None,
+        X_pending: Tensor | None = None,
+    ):
+
         # An objective is required if this aq is used on a multi-output model
         if model.num_outputs > 1:
             objective = IdentityMCMultiOutputObjective()
         else:
             objective = None
 
-        super().__init__(model=model, sampler=sampler, objective=objective,
-                         posterior_transform=posterior_transform, X_pending=X_pending)
+        super().__init__(
+            model=model,
+            sampler=sampler,
+            objective=objective,
+            posterior_transform=posterior_transform,
+            X_pending=X_pending,
+        )
 
-        self.register_buffer('X_baseline', X_baseline)
-        
+        self.register_buffer("X_baseline", X_baseline)
+
     @t_batch_mode_transform()
-    def forward(self,
-                x: Tensor) -> Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         """
         Evaluate the acquisition function on the candidate set x
         """
         # x dimensions: b * q * d
         x_train = self.X_baseline
-        
+
         # For sequential mode, add pending data points to "train"
         if self.X_pending is not None:
             x_train = torch.concat((x_train, self.X_pending))
-               
+
         x = x.unsqueeze(-2)  # Insert expmt dimension before xdim
         x_train = x_train.unsqueeze(0).unsqueeze(0)  # Add batch and q dimensions
-        
+
         # Norm distance over xdim
-        dist = torch.norm(x-x_train, p=2, dim=-1)
-        
+        dist = torch.norm(x - x_train, p=2, dim=-1)
+
         # Min over expmt and q (for joint evaluation)
         closest_dist = dist.min(dim=-1)[0].min(dim=-1)[0]
 
         return closest_dist
 
     @staticmethod
-    def parser(
-        aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
-    ) -> dict[str, Any]:
+    def parser(aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext) -> dict[str, Any]:
         """Parser for Space Filling acquisition function"""
         aq_kwargs["X_baseline"] = context["X_baseline"]
         return aq_kwargs

--- a/obsidian/acquisition/utils.py
+++ b/obsidian/acquisition/utils.py
@@ -4,16 +4,21 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Type, TypedDict
 
 import torch
-from botorch.acquisition.objective import MCAcquisitionObjective
-from botorch.models.model import Model
+from botorch.acquisition.objective import MCAcquisitionObjective, PosteriorTransform
+from botorch.models.model import Model, ModelList
+from botorch.models.model_list_gp_regression import ModelListGP
+from botorch.sampling import SobolQMCNormalSampler
+from botorch.sampling.list_sampler import ListSampler
 from botorch.utils.multi_objective.box_decompositions.non_dominated import (
     NondominatedPartitioning,
 )
 from botorch.utils.sampling import draw_sobol_samples
 
-from obsidian.config import TORCH_DTYPE
-from obsidian.exceptions import UnsupportedError
-from obsidian.surrogates import EnsembleModel
+from ..config import TORCH_DTYPE
+from ..exceptions import UnsupportedError
+from ..parameters import Target
+from ..surrogates import EnsembleModel
+from ..utils import TaskType
 
 
 class ParserContext(TypedDict):
@@ -21,131 +26,18 @@ class ParserContext(TypedDict):
 
     f_t: torch.Tensor
     X_baseline: torch.Tensor
-    objective: Callable | None
-    model: Model
     m_batch: int
     n_dim: int
-    # TODO: rename this variable
-    # the current name is mainly for compatibility with the existing code
-    o: torch.Tensor
+    target: list[Target]
+    generator: torch.Generator | None
+    objective: MCAcquisitionObjective | None
 
 
-# Hyperparameter parsing helpers
-def _ei_hyperparameter_parser(
-    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
-) -> None:
-    """Parser for EI and PI acquisition functions"""
-    o = context["o"]
-    o_max = o.max(dim=0).values * (1 + hps.get("inflate", 0))
-    aq_kwargs["best_f"] = o_max
-
-
-def _ucb_hyperparameter_parser(
-    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
-) -> None:
-    """Parser for UCB acquisition function"""
-    aq_kwargs["beta"] = hps.get("beta", 1.0)
-
-
-def _noisy_parser(
-    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
-) -> None:
-    """Parser for noisy acquisition functions"""
-    aq_kwargs["X_baseline"] = context["X_baseline"]
-    if any(isinstance(m, EnsembleModel) for m in context["model"].models):
-        aq_kwargs["cache_root"] = False
-
-
-def _ref_point(
-    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
-) -> None:
-    """Reference point for hypervolume-based acquisition functions"""
-    o = context["o"]
-    ref_point = hps.get("ref_point")
-    if ref_point is None:
-        max_val = o.max(dim=0).values
-        min_val = o.min(dim=0).values
-        ref_point = min_val - 0.1 * (max_val - min_val)
-    else:
-        ref_point = torch.tensor(ref_point)
-    aq_kwargs["ref_point"] = ref_point
-
-
-def _nipv_hyperparameter_parser(
-    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
-) -> None:
-    """Parser for NIPV acquisition function"""
-    n_dim = context["n_dim"]
-    m_batch = context["m_batch"]
-    objective = context.get("objective")
-
-    X_bounds = torch.tensor([[0.0, 1.0]] * n_dim, dtype=TORCH_DTYPE).T
-    qmc_samples = draw_sobol_samples(bounds=X_bounds, n=128, q=m_batch)
-    aq_kwargs["mc_points"] = qmc_samples.squeeze(-2)
-    aq_kwargs["sampler"] = None
-    if objective:
-        raise UnsupportedError("NIPV does not support objectives")
-
-
-def _sf_hyperparameter_parser(
-    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
-) -> None:
-    """Parser for Space Filling acquisition function"""
-    aq_kwargs["X_baseline"] = context["X_baseline"]
-
-
-# Utility functions for composite parsers
-def _prune_baseline(
-    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
-) -> None:
-    """Parser for functions that need baseline pruning"""
-    aq_kwargs["prune_baseline"] = True
-
-
-def _space_partitioning(
-    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
-) -> None:
-    """Additional parser specific to EHVI"""
-    o = context["o"]
-    aq_kwargs["partitioning"] = NondominatedPartitioning(aq_kwargs["ref_point"], Y=o)
-
-
-def _scalarization_weights_parser(
-    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
-) -> None:
-    """Parser for NParEGO scalarization weights"""
-    w = hps.get("scalarization_weights")
-    if isinstance(w, list):
-        w = torch.tensor(w)
-        w = w / torch.sum(torch.abs(w))
-    aq_kwargs["scalarization_weights"] = w
-
-
-# Composite parsers for acquisition functions that need multiple parsers
-def _nehvi_hyperparameter_parser(
-    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
-) -> None:
-    """Composite parser for NEHVI"""
-    _noisy_parser(aq_kwargs, hps, context)
-    _ref_point(aq_kwargs, hps, context)
-    _prune_baseline(aq_kwargs, hps, context)
-
-
-def _ehvi_hyperparameter_parser(
-    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
-) -> None:
-    """Composite parser for EHVI"""
-    _ref_point(aq_kwargs, hps, context)
-    _space_partitioning(aq_kwargs, hps, context)
-
-
-def _nparego_hyperparameter_parser(
-    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
-) -> None:
-    """Composite parser for NParEGO"""
-    _noisy_parser(aq_kwargs, hps, context)
-    _prune_baseline(aq_kwargs, hps, context)
-    _scalarization_weights_parser(aq_kwargs, hps, context)
+def default_hyperparameter_parser(
+    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext | None = None
+) -> dict[str, Any]:
+    """Default dummy hyperparameter parser"""
+    return aq_kwargs
 
 
 @dataclass
@@ -155,26 +47,16 @@ class AcquisitionConfig:
     name: str
     implementation: type
     hyperparameter_defaults: dict[str, dict[str, Any]] = field(default_factory=dict)
-    hyperparameter_parser: Callable | None = None
+    hyperparameter_parser: Callable[[dict[str, Any], dict[str, Any], Any], dict[str, Any]] = field(
+        default=default_hyperparameter_parser
+    )
     modalities: list[str] = field(default_factory=list)
+    task_types: list[str] = field(default_factory=list)
     is_external: bool = False
-
-    @staticmethod
-    def default_hyperparameter_parser(
-        aq_kwargs: dict[str, Any],
-        hps: dict[str, Any],
-        context: ParserContext | None = None,
-    ) -> None:
-        """Default dummy hyperparameter parser"""
-        pass
 
     def get_default_hyperparameters(self) -> dict[str, Any]:
         """Get default hyperparameter values"""
-        return {
-            key: config["val"]
-            for key, config in self.hyperparameter_defaults.items()
-            if "val" in config
-        }
+        return {key: config["val"] for key, config in self.hyperparameter_defaults.items() if "val" in config}
 
     def merge_with_defaults(self, hps: dict[str, Any]) -> dict[str, Any]:
         """Merge provided hyperparameters with defaults. This method does not perform
@@ -188,11 +70,10 @@ class AcquisitionConfig:
         return self.implementation(**kwargs)
 
     def parse_hyperparameters(
-        self, aq_kwargs: dict[str, Any], hps: dict[str, Any], context: dict[str, Any]
-    ) -> None:
+        self, aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
+    ) -> dict[str, Any]:
         """Apply hyperparameter parser for this acquisition function"""
-        if self.hyperparameter_parser is not None:
-            self.hyperparameter_parser(aq_kwargs, hps, context)
+        return self.hyperparameter_parser(aq_kwargs, hps, context)
 
 
 class AcquisitionRegistry:
@@ -209,67 +90,99 @@ class AcquisitionRegistry:
     def _initialize(self, BUILTIN_CONFIGS: dict[str, dict[str, Any]]):
         """Initialize the registry with default acquisition functions"""
         self.configs: dict[str, AcquisitionConfig] = {}
-        self.valid_aqs: dict[str, dict[str, list[str]]] = {
+        self.valid_aqs: dict[str, dict[str, set[str]]] = {
             "optimization": {
-                "single": [],
-                "multi": [],
-            }
+                "single": set(),
+                "multi": set(),
+            },
+            "characterization": {
+                "single": set(),
+                "multi": set(),
+            },
         }
-        self.valid_char_aqs: set[str] = set()
         self.external_aqs: set[str] = set()
         self.aq_defaults: dict[str, dict[str, str]] = {
             "optimization": {"single": "NEI", "multi": "NEHVI"},
+            "characterization": {"single": "RANDSTR", "multi": "MRANDSTR"},
         }
-        self.universal_opt_aqs: list[str] = ["RS", "Mean", "SF"]
-
+        self.universal_opt_aqs: set[str] = set()
+        self.universal_aqs: set[str] = set()
         # Register built-in functions
         self._register_builtin_functions(BUILTIN_CONFIGS)
+
+    def _register_individual_function(
+        self,
+        name,
+        implementation,
+        hyperparameter_defaults,
+        modalities,
+        task_types,
+        hyperparameter_parser=default_hyperparameter_parser,
+        is_external=False,
+    ):
+        config = AcquisitionConfig(
+            name=name,
+            implementation=implementation,
+            hyperparameter_defaults=hyperparameter_defaults,
+            hyperparameter_parser=hyperparameter_parser,
+            modalities=modalities,
+            task_types=task_types,
+            is_external=is_external,
+        )
+        self.configs[name] = config
+
+        # Add to appropriate lists
+        for task in config.task_types:
+            for modality in config.modalities:
+                # if task == "characterization" and modality == "multi":
+                #     continue
+                self.valid_aqs[task][modality].add(name)
 
     def _register_builtin_functions(self, builtin_configs: dict[str, dict[str, Any]]):
         """Register all built-in acquisition functions from config dictionary"""
         for name, config_data in builtin_configs.items():
-            config = AcquisitionConfig(
-                name=name,
-                implementation=config_data["implementation"],
-                hyperparameter_defaults=config_data["hyperparameter_defaults"],
-                hyperparameter_parser=config_data.get("hyperparameter_parser"),
-                modalities=config_data["modalities"],
-                is_external=False,
-            )
-            self.configs[name] = config
+            self._register_individual_function(name, **config_data)
 
-            # Add to appropriate lists
-            for modality in config.modalities:
-                self.valid_opt_aqs[modality].append(name)
+        single_opt_aqs = self.valid_aqs["optimization"]["single"]
+        multi_opt_aqs = self.valid_aqs["optimization"]["multi"]
+        single_charact_aqs = self.valid_aqs["characterization"]["single"]
+        multi_charact_aqs = self.valid_aqs["characterization"]["multi"]
+        self.universal_opt_aqs = single_opt_aqs & multi_opt_aqs
+        self.universal_charact_aqs = single_charact_aqs & multi_charact_aqs
+        self.universal_aqs = self.universal_aqs & self.universal_charact_aqs
 
     @staticmethod
-    def _filter_botorch_arguments(aq_kwargs: dict[str, Any], hps: dict[str, Any]):
+    def _filter_botorch_arguments(
+        aq_kwargs: dict[str, Any], hps: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
         if "posterior_transform" in hps:
             warnings.warn(
-                "`posterior_transform` is not explicitly handled within the package. Users are solely responsible for using it with the acquisition function."
+                "`posterior_transform` is not explicitly handled within the package. Users are solely responsible for"
+                " using it with the acquisition function."
             )
             aq_kwargs["posterior_transform"] = hps.pop("posterior_transform")
         if "objective" in hps:
-            warnings.warn(
-                "Consider directly passing the objective to the `suggest` function."
-            )
+            warnings.warn("Consider directly passing the objective to the `suggest` function.")
             hps_objective = hps.pop("objective")
             if not aq_kwargs["objective"]:
                 if hps_objective:
-                    warnings.warn(
-                        f"Ignoring provided objective {hps_objective} in favor of {aq_kwargs['objective']}."
-                    )
+                    warnings.warn(f"Ignoring provided objective {hps_objective} in favor of {aq_kwargs['objective']}.")
                 aq_kwargs["objective"] = hps_objective
         for i in ["sampler", "X_pending", "constraints"]:
             if i in hps:
-                warnings.warn(
-                    f"{i.capitalize()} is handled internally by the package, ignoring provided {i} {hps[i]}."
-                )
+                warnings.warn(f"{i.capitalize()} is handled internally by the package, ignoring provided {i} {hps[i]}.")
                 hps.pop(i)
 
+        return aq_kwargs, hps
+
     def validate_hyperparameters(
-        self, o_dim: int, acquisition: str | dict, aq_kwargs: dict[str, Any]
-    ) -> tuple[str, dict]:
+        self,
+        task_type: TaskType,
+        o_dim: int,
+        aq_name: str,
+        hps: dict[str, Any],
+        aq_kwargs: dict[str, Any],
+    ) -> tuple[dict, dict]:
         """
         Validates acquisition function and prepares base arguments.
 
@@ -281,28 +194,21 @@ class AcquisitionRegistry:
         Returns:
             tuple of (aq_name, aq_hps)
         """
-        # Parse acquisition input
-        if isinstance(acquisition, str):
-            aq_name = acquisition
-            hps = {}
-        else:
-            if len(acquisition) != 1:
-                raise ValueError(
-                    "One dictionary of hyperparameters must be provided for each acquisition function"
-                )
-            aq_name, hps = next(iter(acquisition.items()))
-            if not isinstance(hps, dict):
-                raise TypeError("Hyperparameters must be provided as a dictionary")
-        
-        self._filter_botorch_arguments(hps, aq_kwargs)
+        # both dictionaries are modified in-place, return for clarity
+        aq_kwargs, hps = self._filter_botorch_arguments(aq_kwargs, hps)
 
         # Determine optimization type
         optim_type = "single" if o_dim == 1 else "multi"
+        """
+        if task_type.value == "characterization" and optim_type == "multi":
+            raise UnsupportedError("Acquisition functions for characterization tasks does not support multi-objective.")
+        """
 
         # Validate acquisition name
-        if aq_name not in self.valid_opt_aqs[optim_type]:
+        if aq_name not in self.valid_aqs[task_type.value][optim_type]:
             raise UnsupportedError(
-                f"Acquisition function must be selected from: {self.valid_opt_aqs[optim_type]}"
+                f"Acquisition function must be selected from: {self.valid_aqs[task_type.value][optim_type]}."
+                f" {aq_name} for {task_type.value} and {optim_type}-objective is not supported."
             )
 
         # Get config and validate hyperparameters
@@ -313,19 +219,14 @@ class AcquisitionRegistry:
         provided_keys = set(hps.keys())
         unknown_keys = provided_keys - valid_keys
         if unknown_keys:
-            raise ValueError(
-                f"Unknown hyperparameters {unknown_keys} for {aq_name}. "
-                f"Valid options are: {valid_keys}"
-            )
+            raise ValueError(f"Unknown hyperparameters {unknown_keys} for {aq_name}. Valid options are: {valid_keys}")
 
         # Build complete hyperparameters with defaults
         aq_hps = {}
         for key, defaults in config.hyperparameter_defaults.items():
             if hps.get(key) is None:
                 if not defaults.get("optional", True):
-                    raise ValueError(
-                        f"Must specify hyperparameter value {key} for {aq_name}"
-                    )
+                    raise ValueError(f"Must specify hyperparameter value {key} for {aq_name}")
                 # Special handling for weights
                 if key in ["weights", "scalarization_weights"]:
                     aq_hps[key] = [1] * o_dim
@@ -334,13 +235,15 @@ class AcquisitionRegistry:
             else:
                 aq_hps[key] = hps[key]
 
-        return aq_name, aq_hps
+        return aq_kwargs, aq_hps
 
     def register_acquisition_function(
         self,
         name: str,
-        implementation: Type,
+        implementation: Type | None,
         hp_defaults: dict | None = None,
+        is_optimization: bool = False,
+        is_characterization: bool = False,
         is_single_target: bool = False,
         is_multi_target: bool = False,
         set_as_default: bool = False,
@@ -353,24 +256,26 @@ class AcquisitionRegistry:
 
         Parameters:
         - name (str): Name of the acquisition function.
-        - implementation (callable or None): The function implementation.
-        - hp_defaults (dict): Optional hyperparameter defaults.
-            If not specified, a dummy placeholder dict will be constructed by automatically
-            inferring from the acquisition function object, which can be dangerous.
-            It is highly recommended to provide explicit hyperparameter defaults.
+        - implementation (callable or None): The function implementation. If None, no implementation stored.
+        - hp_defaults (dict): Optional hyperparameter defaults. If None and implementation provided, attempt to infer.
+        - task_type (TaskType): Task type this acquisition is intended for (optimization/characterization).
         - is_single_target (bool): Whether this acquisition function is for single-target optimization.
         - is_multi_target (bool): Whether this acquisition function is for multi-target optimization.
-        - overloading (bool): Whether to allow overloading an existing acquisition function with the same name.
-            If False and the acquisition function already exists, a ValueError is raised.
-            If True, the existing acquisition function will be replaced.
         - set_as_default (bool): Whether to set this acquisition function as default for its modality(s).
-        - internal_hyperparameter_parser (bool): Whether to use an internal hyperparameter parser for the
-            acquisition function, assuming the parser already exists for this function.
-            For example, existing function is overloaded, but no new parser needed.
-        - external_hyperparameter_parser (Callable | None, optional): A function to parse arguments for the
-            acquisition function. The parser function should take `aq_kwargs` and `hps` dictionaries
-            as inputs and modify `aq_kwargs` in-place.
+        - overloading (bool): Whether to allow overloading an existing acquisition function with the same name.
+        - internal_hyperparameter_parser (bool): Whether to use an internal hyperparameter parser from an existing config.
+        - external_hyperparameter_parser (Callable | None): A function to parse arguments for the function.
         """
+        # Determine task_types
+        task_types: list[str] = []
+        if is_optimization:
+            task_types.append("optimization")
+        if is_characterization:
+            task_types.append("characterization")
+        if not task_types:
+            raise ValueError(
+                f"Cannot register function '{name}' without specifying task type (optimization or characterization)."
+            )
 
         # Determine modalities
         modalities = []
@@ -382,106 +287,95 @@ class AcquisitionRegistry:
             modalities = ["multi"]
         else:
             raise ValueError(
-                f"Cannot register function '{name}' without specifying target modality "
-                f"(single-target or multi-target)."
+                f"Cannot register function '{name}' without specifying target modality (single-target or multi-target)."
             )
 
-        # Check for conflicts with default acquisitions
-        default_aqs = [name for mod in modalities if self.aq_defaults.get(mod) == name]
+        # For characterization tasks, only single-target is allowed
+        # Comment this block out for experimenting multi-target
+        """
+        tmp_list = task_types + modalities
+        if TaskType.CHARACTERIZATION in task_types and "multi" in modalities and len(tmp_list) < 4:
+            # the logic is this
+            # opt + char / single + multi -> good
+            # opt + char / single -> good
+            # opt + char / single -> good
+            # opt / single + multi -> good
+            # opt / single -> good
+            # opt / multi -> good
+            # char / single -> good
+            # char / multi -> no
+            # opt + char / multi -> no
+            # char / single + multi -> no
+            raise ValueError("Characterization acquisitions must be single-target only (cannot register multi-target).")
+        """
 
-        # Check if function already exists
-        if name in self.configs:
-            if not overloading:
+        # Check existence and overloading
+        exists = name in self.configs
+        if exists and not overloading:
+            raise ValueError(
+                f"Acquisition function '{name}' already registered. To overload the existing function, set"
+                " 'overloading=True'."
+            )
+        if exists and overloading:
+            warnings.warn(f"Overloading existing acquisition function '{name}'.")
+
+        # internal_hyperparameter_parser: only allowed if the existing config has an internal parser
+        hyperparameter_parser = None
+        if internal_hyperparameter_parser:
+            if not exists:
                 raise ValueError(
-                    f"Acquisition function '{name}' already registered. "
-                    f"To overload the existing function, set 'overloading=True'."
+                    "internal_hyperparameter_parser=True requested but acquisition function does not already exist to "
+                    "take the internal parser from."
                 )
-            else:
-                warnings.warn(f"Overloading existing acquisition function '{name}'.")
-                if set_as_default and name in default_aqs:
-                    warnings.warn(
-                        f"Overloading the default acquisition function {name}."
-                    )
+            existing = self.configs.get(name)
+            if not existing or not existing.hyperparameter_parser:
+                raise ValueError(
+                    "internal_hyperparameter_parser=True requested but no internal parser is available on the existing"
+                    " config."
+                )
+            hyperparameter_parser = existing.hyperparameter_parser
 
-                # Remove from existing modality lists
-                for modality_list in self.valid_aqs.values():
-                    if name in modality_list:
-                        modality_list.remove(name)
+        # external parser cannot be combined with internal parser flag
+        if external_hyperparameter_parser is not None:
+            if internal_hyperparameter_parser:
+                raise ValueError(
+                    "Cannot supply both external_hyperparameter_parser and internal_hyperparameter_parser=True."
+                )
+            hyperparameter_parser = external_hyperparameter_parser
 
-        # Extract hyperparameter defaults if not provided
+        # Extract hp_defaults if not provided and implementation is provided
         if hp_defaults is None and implementation is not None:
             hp_defaults = _extract_hp_defaults(implementation)
         elif hp_defaults is None:
             hp_defaults = {}
 
-        # Determine hyperparameter parser
-        hyperparameter_parser = None
-        if external_hyperparameter_parser is not None:
-            if internal_hyperparameter_parser:
-                raise ValueError(
-                    "An external hyperparameter parser is supplied but user also requires "
-                    "using an internal parser."
-                )
-            hyperparameter_parser = external_hyperparameter_parser
-        elif internal_hyperparameter_parser:
-            # Try to use existing parser if available
-            existing_config = self.configs.get(name)
-            if existing_config and existing_config.hyperparameter_parser:
-                hyperparameter_parser = existing_config.hyperparameter_parser
-
-        # Create new configuration
-        config = AcquisitionConfig(
-            name=name,
-            implementation=implementation,
-            hyperparameter_defaults=hp_defaults,
+        self._register_individual_function(
+            name,
+            implementation,
+            hp_defaults,
+            modalities,
+            task_types,
             hyperparameter_parser=hyperparameter_parser,
-            modalities=modalities,
             is_external=True,
         )
-
-        # Register the configuration
-        self.configs[name] = config
-
-        # Add to valid acquisition lists
-        for modality in modalities:
-            if modality in self.valid_opt_aqs:
-                self.valid_opt_aqs[modality].append(name)
-
         # Set as default if requested
         if set_as_default:
-            for modality in modalities:
-                self.aq_defaults["optimization"][modality] = name
-
-    def get_hyperparameter_parser(self, name: str) -> Callable | None:
-        """Get the hyperparameter parser for an acquisition function"""
-        config = self.configs.get(name)
-        return config.hyperparameter_parser if config else None
+            for task in task_types:
+                if task == "optimization":
+                    for mod in modalities:
+                        self.aq_defaults[task][mod] = name
+                elif task == "characterization":
+                    self.aq_defaults[task]["single"] = name
 
     def parse_hyperparameters(
         self,
         name: str,
         aq_kwargs: dict[str, Any],
         hps: dict[str, Any],
-        context: dict[str, Any],
-    ) -> None:
+        context: ParserContext,
+    ) -> dict[str, Any]:
         """Parse hyperparameters for a specific acquisition function"""
-        config = self.configs.get(name)
-        if config:
-            config.parse_hyperparameters(aq_kwargs, hps, context)
-
-    def validate_acquisition(self, name: str, hps: dict[str, Any]) -> None:
-        """Validate acquisition function and its hyperparameters"""
-        if name not in self.configs:
-            raise ValueError(
-                f"Unknown acquisition function '{name}'. "
-                f"Available options: {list(self.configs.keys())}"
-            )
-
-        if not isinstance(hps, dict):
-            raise TypeError("Hyperparameters must be provided as a dictionary")
-
-        config = self.configs[name]
-        config.validate_hyperparameters(hps)
+        return self.get_config(name).parse_hyperparameters(aq_kwargs, hps, context)
 
     def get_config(self, name: str) -> AcquisitionConfig:
         """Get configuration for an acquisition function"""
@@ -499,9 +393,16 @@ class AcquisitionRegistry:
         config = self.get_config(name)
         return set(config.hyperparameter_defaults.keys())
 
-    def process_acquisition_dict(
-        self, acquisition: dict[str, dict[str, Any]]
-    ) -> tuple[str, dict[str, Any]]:
+    def get_default_hyperparameters(self, name: str) -> dict[str, Any]:
+        """Get default hyperparameters for an acquisition function"""
+        config = self.get_config(name)
+        return config.hyperparameter_defaults
+
+    def get_hyperparameter_parser(self, name: str) -> Callable[[dict, dict, ParserContext], dict[str, Any]]:
+        config = self.get_config(name)
+        return config.hyperparameter_parser
+
+    def process_acquisition_dict(self, acquisition: dict[str, dict[str, Any]]) -> tuple[str, dict[str, Any]]:
         """
         Process acquisition dictionary format {name: hyperparameters}
         Returns tuple of (name, validated_hyperparameters)
@@ -525,9 +426,9 @@ class AcquisitionRegistry:
         return self.valid_aqs["optimization"]
 
     @property
-    def universal_aqs(self) -> list[str]:
-        """Backward compatibility for universal_aqs"""
-        return self.universal_opt_aqs
+    def valid_charact_aqs(self) -> dict[str, list[str]]:
+        """Backward compatibility for valid_aqs"""
+        return self.valid_aqs["characterization"]
 
     @property
     def aq_class_dict(self) -> dict[str, type | None]:
@@ -537,10 +438,7 @@ class AcquisitionRegistry:
     @property
     def aq_hp_defaults(self) -> dict[str, dict[str, Any]]:
         """Get dictionary of acquisition function hyperparameter defaults"""
-        return {
-            name: config.hyperparameter_defaults
-            for name, config in self.configs.items()
-        }
+        return {name: config.hyperparameter_defaults for name, config in self.configs.items()}
 
 
 def _extract_hp_defaults(cls):
@@ -562,3 +460,121 @@ def _extract_hp_defaults(cls):
         else:
             hp_defaults[name] = {"val": param.default, "optional": True}
     return hp_defaults
+
+
+# Hyperparameter parsing helpers
+def _objective_transform(context: ParserContext) -> torch.Tensor:
+    f_t = context["f_t"]
+    X_baseline = context["X_baseline"]
+    objective = context.get("objective")
+    return f_t if not objective else objective(f_t.unsqueeze(0), X_baseline).squeeze(0)
+
+
+def _ei_hyperparameter_parser(aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext) -> dict[str, Any]:
+    """Parser for EI and PI acquisition functions"""
+    o = _objective_transform(context)
+    o_max = o.max(dim=0).values * (1 + hps.get("inflate", 0))
+    aq_kwargs["best_f"] = o_max
+    return aq_kwargs
+
+
+def _ucb_hyperparameter_parser(
+    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
+) -> dict[str, Any]:
+    """Parser for UCB acquisition function"""
+    aq_kwargs["beta"] = hps.get("beta", 1.0)
+    return aq_kwargs
+
+
+def _noisy_parser(aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext) -> dict[str, Any]:
+    """Parser for noisy acquisition functions"""
+    aq_kwargs["X_baseline"] = context["X_baseline"]
+    if any(isinstance(m, EnsembleModel) for m in aq_kwargs["model"].models):
+        aq_kwargs["cache_root"] = False
+    return aq_kwargs
+
+
+def _nipv_hyperparameter_parser(
+    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
+) -> dict[str, Any]:
+    """Parser for NIPV acquisition function"""
+    n_dim = context["n_dim"]
+    m_batch = context["m_batch"]
+    objective = context.get("objective")
+
+    X_bounds = torch.tensor([[0.0, 1.0]] * n_dim, dtype=TORCH_DTYPE).T
+    qmc_samples = draw_sobol_samples(bounds=X_bounds, n=128, q=m_batch)
+    aq_kwargs["mc_points"] = qmc_samples.squeeze(-2)
+    aq_kwargs["sampler"] = None
+    if objective:
+        raise UnsupportedError("NIPV does not support objectives")
+    return aq_kwargs
+
+
+# Utility functions for composite parsers
+def _ref_point(aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext) -> None:
+    """Reference point for hypervolume-based acquisition functions"""
+    o = _objective_transform(context)
+    ref_point = hps.get("ref_point")
+    if ref_point is None:
+        max_val = o.max(dim=0).values
+        min_val = o.min(dim=0).values
+        ref_point = min_val - 0.1 * (max_val - min_val)
+    else:
+        ref_point = torch.tensor(ref_point)
+    aq_kwargs["ref_point"] = ref_point
+
+
+def _prune_baseline(aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext) -> None:
+    """Parser for functions that need baseline pruning"""
+    aq_kwargs["prune_baseline"] = True
+
+
+def _space_partitioning(aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext) -> None:
+    """Additional parser specific to EHVI"""
+    o = _objective_transform(context)
+    aq_kwargs["partitioning"] = NondominatedPartitioning(aq_kwargs["ref_point"], Y=o)
+
+
+def _scalarization_weights_parser(aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext) -> None:
+    """Parser for NParEGO scalarization weights"""
+    w = hps.get("scalarization_weights")
+    if isinstance(w, list):
+        w = torch.tensor(w)
+        w = w / torch.sum(torch.abs(w))
+    aq_kwargs["scalarization_weights"] = w
+
+
+# Composite parsers for acquisition functions that need multiple parsers
+def _nehvi_hyperparameter_parser(
+    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
+) -> dict[str, Any]:
+    """Composite parser for NEHVI"""
+    _noisy_parser(aq_kwargs, hps, context)
+    _ref_point(aq_kwargs, hps, context)
+    _prune_baseline(aq_kwargs, hps, context)
+    return aq_kwargs
+
+
+def _ehvi_hyperparameter_parser(
+    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
+) -> dict[str, Any]:
+    """Composite parser for EHVI"""
+    _ref_point(aq_kwargs, hps, context)
+    _space_partitioning(aq_kwargs, hps, context)
+    return aq_kwargs
+
+
+def _nparego_hyperparameter_parser(
+    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
+) -> dict[str, Any]:
+    """Composite parser for NParEGO"""
+    _noisy_parser(aq_kwargs, hps, context)
+    _prune_baseline(aq_kwargs, hps, context)
+    _scalarization_weights_parser(aq_kwargs, hps, context)
+    return aq_kwargs
+
+
+# we explicitly choose the samplers in optimizer
+# this is just a placeholder in case people call the function outside of optimizer
+default_sampler = SobolQMCNormalSampler(sample_shape=torch.Size([512]))

--- a/obsidian/acquisition/utils.py
+++ b/obsidian/acquisition/utils.py
@@ -500,14 +500,13 @@ def _nipv_hyperparameter_parser(
     """Parser for NIPV acquisition function"""
     n_dim = context["n_dim"]
     m_batch = context["m_batch"]
-    objective = context.get("objective")
+    # NIPV does not support custom objectives
+    aq_kwargs.pop("objective")
 
     X_bounds = torch.tensor([[0.0, 1.0]] * n_dim, dtype=TORCH_DTYPE).T
     qmc_samples = draw_sobol_samples(bounds=X_bounds, n=128, q=m_batch)
     aq_kwargs["mc_points"] = qmc_samples.squeeze(-2)
     aq_kwargs["sampler"] = None
-    if objective:
-        raise UnsupportedError("NIPV does not support objectives")
     return aq_kwargs
 
 
@@ -572,6 +571,11 @@ def _nparego_hyperparameter_parser(
     _noisy_parser(aq_kwargs, hps, context)
     _prune_baseline(aq_kwargs, hps, context)
     _scalarization_weights_parser(aq_kwargs, hps, context)
+    return aq_kwargs
+
+
+def dummy_parser(aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext) -> dict[str, Any]:
+    """Dummy parser that does nothing, for compatibility purposes"""
     return aq_kwargs
 
 

--- a/obsidian/acquisition/utils.py
+++ b/obsidian/acquisition/utils.py
@@ -1,0 +1,564 @@
+import inspect
+import warnings
+from dataclasses import dataclass, field
+from typing import Any, Callable, Type, TypedDict
+
+import torch
+from botorch.acquisition.objective import MCAcquisitionObjective
+from botorch.models.model import Model
+from botorch.utils.multi_objective.box_decompositions.non_dominated import (
+    NondominatedPartitioning,
+)
+from botorch.utils.sampling import draw_sobol_samples
+
+from obsidian.config import TORCH_DTYPE
+from obsidian.exceptions import UnsupportedError
+from obsidian.surrogates import EnsembleModel
+
+
+class ParserContext(TypedDict):
+    """Type hints for parser context"""
+
+    f_t: torch.Tensor
+    X_baseline: torch.Tensor
+    objective: Callable | None
+    model: Model
+    m_batch: int
+    n_dim: int
+    # TODO: rename this variable
+    # the current name is mainly for compatibility with the existing code
+    o: torch.Tensor
+
+
+# Hyperparameter parsing helpers
+def _ei_hyperparameter_parser(
+    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
+) -> None:
+    """Parser for EI and PI acquisition functions"""
+    o = context["o"]
+    o_max = o.max(dim=0).values * (1 + hps.get("inflate", 0))
+    aq_kwargs["best_f"] = o_max
+
+
+def _ucb_hyperparameter_parser(
+    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
+) -> None:
+    """Parser for UCB acquisition function"""
+    aq_kwargs["beta"] = hps.get("beta", 1.0)
+
+
+def _noisy_parser(
+    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
+) -> None:
+    """Parser for noisy acquisition functions"""
+    aq_kwargs["X_baseline"] = context["X_baseline"]
+    if any(isinstance(m, EnsembleModel) for m in context["model"].models):
+        aq_kwargs["cache_root"] = False
+
+
+def _ref_point(
+    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
+) -> None:
+    """Reference point for hypervolume-based acquisition functions"""
+    o = context["o"]
+    ref_point = hps.get("ref_point")
+    if ref_point is None:
+        max_val = o.max(dim=0).values
+        min_val = o.min(dim=0).values
+        ref_point = min_val - 0.1 * (max_val - min_val)
+    else:
+        ref_point = torch.tensor(ref_point)
+    aq_kwargs["ref_point"] = ref_point
+
+
+def _nipv_hyperparameter_parser(
+    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
+) -> None:
+    """Parser for NIPV acquisition function"""
+    n_dim = context["n_dim"]
+    m_batch = context["m_batch"]
+    objective = context.get("objective")
+
+    X_bounds = torch.tensor([[0.0, 1.0]] * n_dim, dtype=TORCH_DTYPE).T
+    qmc_samples = draw_sobol_samples(bounds=X_bounds, n=128, q=m_batch)
+    aq_kwargs["mc_points"] = qmc_samples.squeeze(-2)
+    aq_kwargs["sampler"] = None
+    if objective:
+        raise UnsupportedError("NIPV does not support objectives")
+
+
+def _sf_hyperparameter_parser(
+    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
+) -> None:
+    """Parser for Space Filling acquisition function"""
+    aq_kwargs["X_baseline"] = context["X_baseline"]
+
+
+# Utility functions for composite parsers
+def _prune_baseline(
+    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
+) -> None:
+    """Parser for functions that need baseline pruning"""
+    aq_kwargs["prune_baseline"] = True
+
+
+def _space_partitioning(
+    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
+) -> None:
+    """Additional parser specific to EHVI"""
+    o = context["o"]
+    aq_kwargs["partitioning"] = NondominatedPartitioning(aq_kwargs["ref_point"], Y=o)
+
+
+def _scalarization_weights_parser(
+    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
+) -> None:
+    """Parser for NParEGO scalarization weights"""
+    w = hps.get("scalarization_weights")
+    if isinstance(w, list):
+        w = torch.tensor(w)
+        w = w / torch.sum(torch.abs(w))
+    aq_kwargs["scalarization_weights"] = w
+
+
+# Composite parsers for acquisition functions that need multiple parsers
+def _nehvi_hyperparameter_parser(
+    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
+) -> None:
+    """Composite parser for NEHVI"""
+    _noisy_parser(aq_kwargs, hps, context)
+    _ref_point(aq_kwargs, hps, context)
+    _prune_baseline(aq_kwargs, hps, context)
+
+
+def _ehvi_hyperparameter_parser(
+    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
+) -> None:
+    """Composite parser for EHVI"""
+    _ref_point(aq_kwargs, hps, context)
+    _space_partitioning(aq_kwargs, hps, context)
+
+
+def _nparego_hyperparameter_parser(
+    aq_kwargs: dict[str, Any], hps: dict[str, Any], context: ParserContext
+) -> None:
+    """Composite parser for NParEGO"""
+    _noisy_parser(aq_kwargs, hps, context)
+    _prune_baseline(aq_kwargs, hps, context)
+    _scalarization_weights_parser(aq_kwargs, hps, context)
+
+
+@dataclass
+class AcquisitionConfig:
+    """Configuration for an acquisition function"""
+
+    name: str
+    implementation: type
+    hyperparameter_defaults: dict[str, dict[str, Any]] = field(default_factory=dict)
+    hyperparameter_parser: Callable | None = None
+    modalities: list[str] = field(default_factory=list)
+    is_external: bool = False
+
+    @staticmethod
+    def default_hyperparameter_parser(
+        aq_kwargs: dict[str, Any],
+        hps: dict[str, Any],
+        context: ParserContext | None = None,
+    ) -> None:
+        """Default dummy hyperparameter parser"""
+        pass
+
+    def get_default_hyperparameters(self) -> dict[str, Any]:
+        """Get default hyperparameter values"""
+        return {
+            key: config["val"]
+            for key, config in self.hyperparameter_defaults.items()
+            if "val" in config
+        }
+
+    def merge_with_defaults(self, hps: dict[str, Any]) -> dict[str, Any]:
+        """Merge provided hyperparameters with defaults. This method does not perform
+        validation or parsing, so users should ensure that the provided hyperparameters
+        are valid and all required hyperparameters are included."""
+        defaults = self.get_default_hyperparameters()
+        return {**defaults, **hps}
+
+    def instantiate(self, **kwargs) -> Any:
+        """Instantiate the acquisition function with given parameters"""
+        return self.implementation(**kwargs)
+
+    def parse_hyperparameters(
+        self, aq_kwargs: dict[str, Any], hps: dict[str, Any], context: dict[str, Any]
+    ) -> None:
+        """Apply hyperparameter parser for this acquisition function"""
+        if self.hyperparameter_parser is not None:
+            self.hyperparameter_parser(aq_kwargs, hps, context)
+
+
+class AcquisitionRegistry:
+    """Singleton registry for acquisition function configurations"""
+
+    _instance = None
+
+    def __new__(cls, BUILTIN_CONFIGS: dict[str, dict[str, Any]]):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._initialize(BUILTIN_CONFIGS)
+        return cls._instance
+
+    def _initialize(self, BUILTIN_CONFIGS: dict[str, dict[str, Any]]):
+        """Initialize the registry with default acquisition functions"""
+        self.configs: dict[str, AcquisitionConfig] = {}
+        self.valid_aqs: dict[str, dict[str, list[str]]] = {
+            "optimization": {
+                "single": [],
+                "multi": [],
+            }
+        }
+        self.valid_char_aqs: set[str] = set()
+        self.external_aqs: set[str] = set()
+        self.aq_defaults: dict[str, dict[str, str]] = {
+            "optimization": {"single": "NEI", "multi": "NEHVI"},
+        }
+        self.universal_opt_aqs: list[str] = ["RS", "Mean", "SF"]
+
+        # Register built-in functions
+        self._register_builtin_functions(BUILTIN_CONFIGS)
+
+    def _register_builtin_functions(self, builtin_configs: dict[str, dict[str, Any]]):
+        """Register all built-in acquisition functions from config dictionary"""
+        for name, config_data in builtin_configs.items():
+            config = AcquisitionConfig(
+                name=name,
+                implementation=config_data["implementation"],
+                hyperparameter_defaults=config_data["hyperparameter_defaults"],
+                hyperparameter_parser=config_data.get("hyperparameter_parser"),
+                modalities=config_data["modalities"],
+                is_external=False,
+            )
+            self.configs[name] = config
+
+            # Add to appropriate lists
+            for modality in config.modalities:
+                self.valid_opt_aqs[modality].append(name)
+
+    @staticmethod
+    def _filter_botorch_arguments(aq_kwargs: dict[str, Any], hps: dict[str, Any]):
+        if "posterior_transform" in hps:
+            warnings.warn(
+                "`posterior_transform` is not explicitly handled within the package. Users are solely responsible for using it with the acquisition function."
+            )
+            aq_kwargs["posterior_transform"] = hps.pop("posterior_transform")
+        if "objective" in hps:
+            warnings.warn(
+                "Consider directly passing the objective to the `suggest` function."
+            )
+            hps_objective = hps.pop("objective")
+            if not aq_kwargs["objective"]:
+                if hps_objective:
+                    warnings.warn(
+                        f"Ignoring provided objective {hps_objective} in favor of {aq_kwargs['objective']}."
+                    )
+                aq_kwargs["objective"] = hps_objective
+        for i in ["sampler", "X_pending", "constraints"]:
+            if i in hps:
+                warnings.warn(
+                    f"{i.capitalize()} is handled internally by the package, ignoring provided {i} {hps[i]}."
+                )
+                hps.pop(i)
+
+    def validate_hyperparameters(
+        self, o_dim: int, acquisition: str | dict, aq_kwargs: dict[str, Any]
+    ) -> tuple[str, dict]:
+        """
+        Validates acquisition function and prepares base arguments.
+
+        Args:
+            o_dim: Output dimensionality
+            acquisition: Acquisition function name (str) or {name: hyperparameters} dict
+            aq_kwargs: Base keyword arguments for the acquisition function
+
+        Returns:
+            tuple of (aq_name, aq_hps)
+        """
+        # Parse acquisition input
+        if isinstance(acquisition, str):
+            aq_name = acquisition
+            hps = {}
+        else:
+            if len(acquisition) != 1:
+                raise ValueError(
+                    "One dictionary of hyperparameters must be provided for each acquisition function"
+                )
+            aq_name, hps = next(iter(acquisition.items()))
+            if not isinstance(hps, dict):
+                raise TypeError("Hyperparameters must be provided as a dictionary")
+        
+        self._filter_botorch_arguments(hps, aq_kwargs)
+
+        # Determine optimization type
+        optim_type = "single" if o_dim == 1 else "multi"
+
+        # Validate acquisition name
+        if aq_name not in self.valid_opt_aqs[optim_type]:
+            raise UnsupportedError(
+                f"Acquisition function must be selected from: {self.valid_opt_aqs[optim_type]}"
+            )
+
+        # Get config and validate hyperparameters
+        config = self.get_config(aq_name)
+
+        # Check for unknown hyperparameters
+        valid_keys = set(config.hyperparameter_defaults.keys())
+        provided_keys = set(hps.keys())
+        unknown_keys = provided_keys - valid_keys
+        if unknown_keys:
+            raise ValueError(
+                f"Unknown hyperparameters {unknown_keys} for {aq_name}. "
+                f"Valid options are: {valid_keys}"
+            )
+
+        # Build complete hyperparameters with defaults
+        aq_hps = {}
+        for key, defaults in config.hyperparameter_defaults.items():
+            if hps.get(key) is None:
+                if not defaults.get("optional", True):
+                    raise ValueError(
+                        f"Must specify hyperparameter value {key} for {aq_name}"
+                    )
+                # Special handling for weights
+                if key in ["weights", "scalarization_weights"]:
+                    aq_hps[key] = [1] * o_dim
+                else:
+                    aq_hps[key] = defaults.get("val")
+            else:
+                aq_hps[key] = hps[key]
+
+        return aq_name, aq_hps
+
+    def register_acquisition_function(
+        self,
+        name: str,
+        implementation: Type,
+        hp_defaults: dict | None = None,
+        is_single_target: bool = False,
+        is_multi_target: bool = False,
+        set_as_default: bool = False,
+        overloading: bool = False,
+        internal_hyperparameter_parser: bool = False,
+        external_hyperparameter_parser: Callable | None = None,
+    ):
+        """
+        Register a new acquisition function.
+
+        Parameters:
+        - name (str): Name of the acquisition function.
+        - implementation (callable or None): The function implementation.
+        - hp_defaults (dict): Optional hyperparameter defaults.
+            If not specified, a dummy placeholder dict will be constructed by automatically
+            inferring from the acquisition function object, which can be dangerous.
+            It is highly recommended to provide explicit hyperparameter defaults.
+        - is_single_target (bool): Whether this acquisition function is for single-target optimization.
+        - is_multi_target (bool): Whether this acquisition function is for multi-target optimization.
+        - overloading (bool): Whether to allow overloading an existing acquisition function with the same name.
+            If False and the acquisition function already exists, a ValueError is raised.
+            If True, the existing acquisition function will be replaced.
+        - set_as_default (bool): Whether to set this acquisition function as default for its modality(s).
+        - internal_hyperparameter_parser (bool): Whether to use an internal hyperparameter parser for the
+            acquisition function, assuming the parser already exists for this function.
+            For example, existing function is overloaded, but no new parser needed.
+        - external_hyperparameter_parser (Callable | None, optional): A function to parse arguments for the
+            acquisition function. The parser function should take `aq_kwargs` and `hps` dictionaries
+            as inputs and modify `aq_kwargs` in-place.
+        """
+
+        # Determine modalities
+        modalities = []
+        if is_single_target and is_multi_target:
+            modalities = ["single", "multi"]
+        elif is_single_target:
+            modalities = ["single"]
+        elif is_multi_target:
+            modalities = ["multi"]
+        else:
+            raise ValueError(
+                f"Cannot register function '{name}' without specifying target modality "
+                f"(single-target or multi-target)."
+            )
+
+        # Check for conflicts with default acquisitions
+        default_aqs = [name for mod in modalities if self.aq_defaults.get(mod) == name]
+
+        # Check if function already exists
+        if name in self.configs:
+            if not overloading:
+                raise ValueError(
+                    f"Acquisition function '{name}' already registered. "
+                    f"To overload the existing function, set 'overloading=True'."
+                )
+            else:
+                warnings.warn(f"Overloading existing acquisition function '{name}'.")
+                if set_as_default and name in default_aqs:
+                    warnings.warn(
+                        f"Overloading the default acquisition function {name}."
+                    )
+
+                # Remove from existing modality lists
+                for modality_list in self.valid_aqs.values():
+                    if name in modality_list:
+                        modality_list.remove(name)
+
+        # Extract hyperparameter defaults if not provided
+        if hp_defaults is None and implementation is not None:
+            hp_defaults = _extract_hp_defaults(implementation)
+        elif hp_defaults is None:
+            hp_defaults = {}
+
+        # Determine hyperparameter parser
+        hyperparameter_parser = None
+        if external_hyperparameter_parser is not None:
+            if internal_hyperparameter_parser:
+                raise ValueError(
+                    "An external hyperparameter parser is supplied but user also requires "
+                    "using an internal parser."
+                )
+            hyperparameter_parser = external_hyperparameter_parser
+        elif internal_hyperparameter_parser:
+            # Try to use existing parser if available
+            existing_config = self.configs.get(name)
+            if existing_config and existing_config.hyperparameter_parser:
+                hyperparameter_parser = existing_config.hyperparameter_parser
+
+        # Create new configuration
+        config = AcquisitionConfig(
+            name=name,
+            implementation=implementation,
+            hyperparameter_defaults=hp_defaults,
+            hyperparameter_parser=hyperparameter_parser,
+            modalities=modalities,
+            is_external=True,
+        )
+
+        # Register the configuration
+        self.configs[name] = config
+
+        # Add to valid acquisition lists
+        for modality in modalities:
+            if modality in self.valid_opt_aqs:
+                self.valid_opt_aqs[modality].append(name)
+
+        # Set as default if requested
+        if set_as_default:
+            for modality in modalities:
+                self.aq_defaults["optimization"][modality] = name
+
+    def get_hyperparameter_parser(self, name: str) -> Callable | None:
+        """Get the hyperparameter parser for an acquisition function"""
+        config = self.configs.get(name)
+        return config.hyperparameter_parser if config else None
+
+    def parse_hyperparameters(
+        self,
+        name: str,
+        aq_kwargs: dict[str, Any],
+        hps: dict[str, Any],
+        context: dict[str, Any],
+    ) -> None:
+        """Parse hyperparameters for a specific acquisition function"""
+        config = self.configs.get(name)
+        if config:
+            config.parse_hyperparameters(aq_kwargs, hps, context)
+
+    def validate_acquisition(self, name: str, hps: dict[str, Any]) -> None:
+        """Validate acquisition function and its hyperparameters"""
+        if name not in self.configs:
+            raise ValueError(
+                f"Unknown acquisition function '{name}'. "
+                f"Available options: {list(self.configs.keys())}"
+            )
+
+        if not isinstance(hps, dict):
+            raise TypeError("Hyperparameters must be provided as a dictionary")
+
+        config = self.configs[name]
+        config.validate_hyperparameters(hps)
+
+    def get_config(self, name: str) -> AcquisitionConfig:
+        """Get configuration for an acquisition function"""
+        if name not in self.configs:
+            raise ValueError(f"Unknown acquisition function '{name}'")
+        return self.configs[name]
+
+    def instantiate_acquisition(self, name: str, **kwargs) -> Any:
+        """Instantiate an acquisition function with parameters"""
+        config = self.get_config(name)
+        return config.instantiate(**kwargs)
+
+    def get_valid_hyperparameters(self, name: str) -> set[str]:
+        """Get valid hyperparameter names for an acquisition function"""
+        config = self.get_config(name)
+        return set(config.hyperparameter_defaults.keys())
+
+    def process_acquisition_dict(
+        self, acquisition: dict[str, dict[str, Any]]
+    ) -> tuple[str, dict[str, Any]]:
+        """
+        Process acquisition dictionary format {name: hyperparameters}
+        Returns tuple of (name, validated_hyperparameters)
+        """
+        if len(acquisition) != 1:
+            raise ValueError("Acquisition dict must have exactly one key")
+
+        aq_name, hps = next(iter(acquisition.items()))
+        self.validate_acquisition(aq_name, hps)
+
+        # merge with defaults
+        config = self.get_config(aq_name)
+        merged_hps = config.merge_with_defaults(hps)
+
+        return aq_name, merged_hps
+
+    # Properties for backward compatibility
+    @property
+    def valid_opt_aqs(self) -> dict[str, list[str]]:
+        """Backward compatibility for valid_aqs"""
+        return self.valid_aqs["optimization"]
+
+    @property
+    def universal_aqs(self) -> list[str]:
+        """Backward compatibility for universal_aqs"""
+        return self.universal_opt_aqs
+
+    @property
+    def aq_class_dict(self) -> dict[str, type | None]:
+        """Get dictionary of acquisition function implementations"""
+        return {name: config.implementation for name, config in self.configs.items()}
+
+    @property
+    def aq_hp_defaults(self) -> dict[str, dict[str, Any]]:
+        """Get dictionary of acquisition function hyperparameter defaults"""
+        return {
+            name: config.hyperparameter_defaults
+            for name, config in self.configs.items()
+        }
+
+
+def _extract_hp_defaults(cls):
+    """
+    Extract constructor parameters and their default values from a class.
+
+    Returns a dict mapping parameter names to default values or None if no default.
+    Skips 'self' and 'model' parameters.
+    """
+    sig = inspect.signature(cls.__init__)
+    hp_defaults = {}
+    for name, param in sig.parameters.items():
+        # assume all custom acquisition functions use `model` as the variable name
+        # for the Gaussian process model
+        if name in ("self", "model"):
+            continue
+        if param.default is inspect.Parameter.empty:
+            hp_defaults[name] = {"val": None, "optional": False}
+        else:
+            hp_defaults[name] = {"val": param.default, "optional": True}
+    return hp_defaults

--- a/obsidian/campaign/campaign.py
+++ b/obsidian/campaign/campaign.py
@@ -59,6 +59,7 @@ class Campaign():
             optimizer_seed = seed
             designer_seed = seed
             torch_rng = None
+            warnings.warn("Using old RNG control. This is deprecated.", UserWarning)
         else:
             if rng is None:
                 self.rng = obsidian.create_rng_manager(seed)
@@ -75,7 +76,7 @@ class Campaign():
                         "Both `rng` and `seed` were provided. The seed parameter will be ignored "
                         "in favor of the seed from `rng`.", UserWarning
                     )
-                seed = self.rng.seed
+            seed = self.rng.seed
 
             torch_rng = self.rng.torch_rng
             optimizer_seed = seed
@@ -497,19 +498,32 @@ class Campaign():
 
         # Restore RNG state if saved
         rng = None
+        seed=obj_dict['seed']
         if 'rng_state' in obj_dict and obj_dict['rng_state'] is not None:
             rng = RNGManager.load_state(obj_dict['rng_state'])
+        else:
+            msg = "Loading a legacy campaign save.\nA new RNG manager object will be created to control randomness.\n"
+            if seed is None:
+                msg += "A random seed will be assigned due to seed is none."
+            else:
+                msg += f"Seed {seed} will be used to initialize the new RNG manager."
+            msg += "\nNote that due to the differences in random states by design, campaign results will be different.\nTo fully recover legacy behavior, set `obsidian.USE_OLD_RNG_CONTROL = True` before loading."
+            warnings.warn(msg, UserWarning)
 
         new_campaign = cls(X_space=ParamSpace.load_state(obj_dict['X_space']),
                            target=[Target.load_state(t_dict) for t_dict in obj_dict['target']],
                            optimizer=BayesianOptimizer.load_state(obj_dict['optimizer']),
                            objective=new_objective,
-                           seed=obj_dict['seed'],
+                           seed=seed,
                            rng=rng)
         new_campaign.data = pd.DataFrame(obj_dict['data'])
         new_campaign.data.index = new_campaign.data.index.astype('int')
-        
+
         new_campaign.iter = new_campaign.data['Iteration'].astype('int').max()
+
+        # Restore owns_rng flag (gets overwritten during __init__ when rng is passed)
+        if 'owns_rng' in obj_dict:
+            new_campaign._owns_rng = obj_dict['owns_rng']
 
         if 'output_constraints' in obj_dict:
             for const_dict in obj_dict['output_constraints']:

--- a/obsidian/campaign/campaign.py
+++ b/obsidian/campaign/campaign.py
@@ -519,7 +519,11 @@ class Campaign():
         new_campaign.data = pd.DataFrame(obj_dict['data'])
         new_campaign.data.index = new_campaign.data.index.astype('int')
 
-        new_campaign.iter = new_campaign.data['Iteration'].astype('int').max()
+        # Handle empty data
+        if len(new_campaign.data) > 0 and 'Iteration' in new_campaign.data.columns:
+            new_campaign.iter = new_campaign.data['Iteration'].astype('int').max()
+        else:
+            new_campaign.iter = 0
 
         # Restore owns_rng flag (gets overwritten during __init__ when rng is passed)
         if 'owns_rng' in obj_dict:

--- a/obsidian/campaign/campaign.py
+++ b/obsidian/campaign/campaign.py
@@ -7,6 +7,7 @@ from obsidian.objectives import Objective, Objective_Sequence, obj_class_dict
 from obsidian.constraints import Output_Constraint, const_class_dict
 from obsidian.exceptions import IncompatibleObjectiveError
 from obsidian.utils import tensordict_to_dict
+from obsidian.rng import GlobalRNG
 import obsidian
 
 import pandas as pd
@@ -49,25 +50,28 @@ class Campaign():
                  designer: ExpDesigner | None = None,
                  objective: Objective | None = None,
                  seed: int | None = None,
-                 unique_seeds: bool = False
+                 global_rng: GlobalRNG | None = None
                  ):
         
         self.set_X_space(X_space)
         self.data = pd.DataFrame()
-        
-        print("Primary seed", seed)
-        if unique_seeds:
-            if seed is not None:
-                self.primary_rng = torch.Generator().manual_seed(seed)
-            else:
-                self.primary_rng = torch.Generator()
-            optimizer_seed, designer_seed = map(int, torch.randint(0, 1_000_000, (2,), generator=self.primary_rng))
+        if obsidian.USE_OLD_RNG_CONTROL:
+            optimizer_seed = seed
+            designer_seed = seed
+            torch_rng = None
         else:
-            optimizer_seed, designer_seed = seed, seed
+            if not global_rng:
+                global_rng = obsidian.get_global_rng(seed)
+            # optimizer_seed = global_rng.np_rng
+            # designer_seed = global_rng.np_rng
+            optimizer_seed = seed
+            designer_seed = seed
+            torch_rng = global_rng.torch_rng
+            self.global_rng = global_rng
         optimizer = BayesianOptimizer(X_space, seed=optimizer_seed) if optimizer is None else optimizer
         self.set_optimizer(optimizer)
 
-        designer = ExpDesigner(X_space, seed=designer_seed) if designer is None else designer
+        designer = ExpDesigner(X_space, seed=designer_seed, torch_rng=torch_rng) if designer is None else designer
         self.set_designer(designer)
         
         self.set_target(target)
@@ -295,8 +299,8 @@ class Campaign():
         Maps ExpDesigner.initialize method
         """
         return self.designer.initialize(**design_kwargs)
-    
-    def fit(self):
+
+    def fit(self, fit_options: dict = {}):
         """
         Maps Optimizer.fit method
 
@@ -307,7 +311,7 @@ class Campaign():
         if self.m_exp <= 0:
             raise ValueError('Must register data before fitting')
 
-        self.optimizer.fit(self.data, target=self.target)
+        self.optimizer.fit(self.data, target=self.target, fit_options=fit_options)
 
     def suggest(self, **optim_kwargs):
         """

--- a/obsidian/campaign/campaign.py
+++ b/obsidian/campaign/campaign.py
@@ -7,7 +7,7 @@ from obsidian.objectives import Objective, Objective_Sequence, obj_class_dict
 from obsidian.constraints import Output_Constraint, const_class_dict
 from obsidian.exceptions import IncompatibleObjectiveError
 from obsidian.utils import tensordict_to_dict
-from obsidian.rng import GlobalRNG
+from obsidian.rng import RNGManager
 import obsidian
 
 import pandas as pd
@@ -50,9 +50,9 @@ class Campaign():
                  designer: ExpDesigner | None = None,
                  objective: Objective | None = None,
                  seed: int | None = None,
-                 global_rng: GlobalRNG | None = None
+                 rng: RNGManager | None = None
                  ):
-        
+
         self.set_X_space(X_space)
         self.data = pd.DataFrame()
         if obsidian.USE_OLD_RNG_CONTROL:
@@ -60,18 +60,42 @@ class Campaign():
             designer_seed = seed
             torch_rng = None
         else:
-            if not global_rng:
-                global_rng = obsidian.get_global_rng(seed)
-            # optimizer_seed = global_rng.np_rng
-            # designer_seed = global_rng.np_rng
+            if rng is None:
+                self.rng = obsidian.create_rng_manager(seed)
+                self._owns_rng = True
+            else:
+                # User provided explicit RNG to share
+                self.rng = rng
+                self._owns_rng = False
+                print(
+                    "Campaign is using a shared RNGManager instance. Reproducibility will depend how other objects consume from this RNG."
+                )
+                if seed is not None:
+                    warnings.warn(
+                        "Both `rng` and `seed` were provided. The seed parameter will be ignored "
+                        "in favor of the seed from `rng`.", UserWarning
+                    )
+                seed = self.rng.seed
+
+            torch_rng = self.rng.torch_rng
             optimizer_seed = seed
             designer_seed = seed
-            torch_rng = global_rng.torch_rng
-            self.global_rng = global_rng
-        optimizer = BayesianOptimizer(X_space, seed=optimizer_seed) if optimizer is None else optimizer
+
+        if not optimizer:
+            optimizer = BayesianOptimizer(
+                X_space,
+                rng=self.rng if not obsidian.USE_OLD_RNG_CONTROL else None,
+                seed=optimizer_seed
+            )
         self.set_optimizer(optimizer)
 
-        designer = ExpDesigner(X_space, seed=designer_seed, torch_rng=torch_rng) if designer is None else designer
+        if not designer:
+            designer = ExpDesigner(
+                X_space,
+                seed=designer_seed,
+                torch_rng=torch_rng,
+                np_rng=self.rng.np_rng if not obsidian.USE_OLD_RNG_CONTROL else None
+            )
         self.set_designer(designer)
         
         self.set_target(target)
@@ -433,6 +457,14 @@ class Campaign():
             obj_dict['objective'] = self.objective.save_state()
         obj_dict['seed'] = self.seed
 
+        # Save RNG state for reproducibility
+        if hasattr(self, 'rng'):
+            obj_dict['rng_state'] = self.rng.save_state()
+            obj_dict['owns_rng'] = getattr(self, '_owns_rng', False)
+        else:
+            obj_dict['rng_state'] = None
+            obj_dict['owns_rng'] = False
+
         if getattr(self, 'output_constraints', None):
             obj_dict['output_constraints'] = [{'class': const.__class__.__name__,
                                                'state': tensordict_to_dict(const.state_dict())}
@@ -462,12 +494,18 @@ class Campaign():
                 new_objective = obj_class.load_state(obj_dict['objective'])
         else:
             new_objective = None
-        
+
+        # Restore RNG state if saved
+        rng = None
+        if 'rng_state' in obj_dict and obj_dict['rng_state'] is not None:
+            rng = RNGManager.load_state(obj_dict['rng_state'])
+
         new_campaign = cls(X_space=ParamSpace.load_state(obj_dict['X_space']),
                            target=[Target.load_state(t_dict) for t_dict in obj_dict['target']],
                            optimizer=BayesianOptimizer.load_state(obj_dict['optimizer']),
                            objective=new_objective,
-                           seed=obj_dict['seed'])
+                           seed=obj_dict['seed'],
+                           rng=rng)
         new_campaign.data = pd.DataFrame(obj_dict['data'])
         new_campaign.data.index = new_campaign.data.index.astype('int')
         

--- a/obsidian/campaign/campaign.py
+++ b/obsidian/campaign/campaign.py
@@ -48,15 +48,26 @@ class Campaign():
                  optimizer: Optimizer | None = None,
                  designer: ExpDesigner | None = None,
                  objective: Objective | None = None,
-                 seed: int | None = None):
+                 seed: int | None = None,
+                 unique_seeds: bool = False
+                 ):
         
         self.set_X_space(X_space)
         self.data = pd.DataFrame()
         
-        optimizer = BayesianOptimizer(X_space, seed=seed) if optimizer is None else optimizer
+        print("Primary seed", seed)
+        if unique_seeds:
+            if seed is not None:
+                self.primary_rng = torch.Generator().manual_seed(seed)
+            else:
+                self.primary_rng = torch.Generator()
+            optimizer_seed, designer_seed = map(int, torch.randint(0, 1_000_000, (2,), generator=self.primary_rng))
+        else:
+            optimizer_seed, designer_seed = seed, seed
+        optimizer = BayesianOptimizer(X_space, seed=optimizer_seed) if optimizer is None else optimizer
         self.set_optimizer(optimizer)
 
-        designer = ExpDesigner(X_space, seed=seed) if designer is None else designer
+        designer = ExpDesigner(X_space, seed=designer_seed) if designer is None else designer
         self.set_designer(designer)
         
         self.set_target(target)

--- a/obsidian/campaign/campaign.py
+++ b/obsidian/campaign/campaign.py
@@ -219,7 +219,14 @@ class Campaign():
             self._target = [target]
         else:
             self._target = target
-
+        if all(t.tracking_only for t in self._target):
+            warnings.warn(
+                "All targets are tracking-only. Campaign will not optimize towards any target by default. "
+                "Only use this campaign for analyzing data or informational purposes. "
+                "Pass tracking-only targets explicitly to `suggest` to optimize towards them if this is truly intended.",
+                UserWarning,
+                stacklevel=2,
+            )
         self.y_names = [t.name for t in self._target]
         self.n_response = len(self.y_names)
 

--- a/obsidian/campaign/explainer.py
+++ b/obsidian/campaign/explainer.py
@@ -1,8 +1,10 @@
 """Explainer Class: Surrogate Model Interpretation Methods"""
 
+import obsidian
 from obsidian.parameters import Param_Continuous, ParamSpace
 from obsidian.optimizer import Optimizer
 from obsidian.exceptions import UnfitError
+from obsidian.rng import get_new_seed, with_tmp_seed
 
 import shap
 from shap import KernelExplainer, Explanation
@@ -13,6 +15,7 @@ import pandas as pd
 import torch
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
+from contextlib import nullcontext
 
 
 class Explainer():
@@ -102,15 +105,32 @@ class Explainer():
             y_pred = self.optimizer.predict(X, return_f_inv=True)
             mu = y_pred[y_name+' (pred)'].values
             return mu
-        
+
+
         self.shap['pred_func'] = pred_func
         self.shap['explainer'] = KernelExplainer(pred_func,  X_ref)
-        self.shap['X_sample'] = self.X_space.unit_demap(
-            pd.DataFrame(torch.rand(size=(n, self.X_space.n_dim)).numpy(),
-                         columns=X_ref.columns)
+        if obsidian.USE_OLD_RNG_CONTROL:
+            torch_rng = None
+            # dummy context manager
+            ctx_mgr = nullcontext()
+        else:
+            torch_rng = getattr(self.optimizer, "torch_rng", None)
+            # temporarily override global random states
+            tmp_seed: int = get_new_seed(1, torch_rng) # type: ignore
+            ctx_mgr = with_tmp_seed(tmp_seed)
+
+        self.shap["X_sample"] = self.X_space.unit_demap(
+            pd.DataFrame(
+                torch.rand(size=(n, self.X_space.n_dim), generator=torch_rng).numpy(),
+                columns=X_ref.columns,
             )
-        self.shap['values'] = self.shap['explainer'].shap_values(self.shap['X_sample'],
-                                                                 seed=seed, l1_reg='aic')
+        )
+        with ctx_mgr:
+            self.shap["values"] = self.shap["explainer"].shap_values(
+                self.shap["X_sample"],
+                seed=seed,
+                l1_reg="aic",
+            )
         self.shap['explanation'] = Explanation(self.shap['values'], feature_names=X_ref.columns)
 
         return

--- a/obsidian/experiment/benchmark/optithon.py
+++ b/obsidian/experiment/benchmark/optithon.py
@@ -5,6 +5,7 @@ Simulation functions used for an optimization hackathon (OptiThon) in March 2024
 import numpy as np
 import pandas as pd
 from scipy.special import gamma
+from numpy.random import Generator
 
 
 def Vm_func(X):
@@ -61,7 +62,7 @@ def response_2(X):
     return E_curve
 
 
-def OT_simulator(X, addNoise=False):
+def OT_simulator(X, addNoise=False, generator=None):
     if isinstance(X, pd.DataFrame):
         X = X.to_numpy()
     if isinstance(X, np.ndarray) and X.ndim == 1:
@@ -88,7 +89,10 @@ def OT_simulator(X, addNoise=False):
     # Note: The overall problem is slightly heteroskedastic
     if addNoise:
         sd = 0.01+0.02*X6
-        rel_error = np.random.normal(loc=1, scale=sd, size=y.shape[0])
+        if isinstance(generator, Generator):
+            rel_error = generator.normal(loc=1, scale=sd, size=y.shape[0])
+        else:
+            rel_error = np.random.normal(loc=1, scale=sd, size=y.shape[0])
         y *= rel_error
     
     return y

--- a/obsidian/experiment/benchmark/optithon.py
+++ b/obsidian/experiment/benchmark/optithon.py
@@ -68,13 +68,15 @@ def OT_simulator(X, addNoise=False, generator=None):
     if isinstance(X, np.ndarray) and X.ndim == 1:
         X = X[np.newaxis, :]
 
-    if X.shape[1] != 6:
+    if not addNoise:
+        if X.shape[1] != 5 and X.shape[1] != 6:
+            raise ValueError(f'Input to simulate must have 5 or 6 columns for no noise case, not {X.shape[1]}')
+    elif X.shape[1] != 6:
         raise ValueError(f'Input to simulate must have 6 columns, not {X.shape[1]}')
     
     # Break down the data into 3 parts for separate functions
     X123 = X[:, 0:3]
     X45 = X[:, 3:5]
-    X6 = X[:, 5]
     
     # First three cols represented in an enzyme kinetics problem
     y1 = response_1(X123)
@@ -88,6 +90,7 @@ def OT_simulator(X, addNoise=False, generator=None):
     # Final column has a mean 0 effect, but determines the scale of noise
     # Note: The overall problem is slightly heteroskedastic
     if addNoise:
+        X6 = X[:, 5]
         sd = 0.01+0.02*X6
         if isinstance(generator, Generator):
             rel_error = generator.normal(loc=1, scale=sd, size=y.shape[0])

--- a/obsidian/experiment/design.py
+++ b/obsidian/experiment/design.py
@@ -31,17 +31,24 @@ class ExpDesigner:
     def __init__(self,
                  X_space: ParamSpace,
                  seed: np.random.Generator | int | None = None,
-                 torch_rng: torch.Generator | None = None
+                 torch_rng: torch.Generator | None = None,
+                 np_rng: np.random.Generator | None = None
                  ):
         if not isinstance(X_space, ParamSpace):
             raise TypeError('X_space must be an obsidian ParamSpace object')
-        
+
         self.X_space = X_space
         self.seed = seed
         if torch_rng:
             if not isinstance(torch_rng, torch.Generator):
                 raise TypeError('torch_rng must be a torch.Generator object')
         self.torch_rng = torch_rng
+
+        # Store numpy RNG for future use
+        if np_rng:
+            if not isinstance(np_rng, np.random.Generator):
+                raise TypeError('np_rng must be a numpy.random.Generator object')
+        self.np_rng = np_rng
 
     def __repr__(self):
         """String representation of object"""

--- a/obsidian/experiment/design.py
+++ b/obsidian/experiment/design.py
@@ -6,6 +6,7 @@ from obsidian.parameters import ParamSpace
 from obsidian.exceptions import UnsupportedError
 
 from botorch.utils.sampling import draw_sobol_samples
+import numpy as np
 from numpy.typing import ArrayLike
 from scipy.stats import qmc
 
@@ -29,12 +30,18 @@ class ExpDesigner:
 
     def __init__(self,
                  X_space: ParamSpace,
-                 seed: int | None = None):
+                 seed: np.random.Generator | int | None = None,
+                 torch_rng: torch.Generator | None = None
+                 ):
         if not isinstance(X_space, ParamSpace):
             raise TypeError('X_space must be an obsidian ParamSpace object')
         
         self.X_space = X_space
         self.seed = seed
+        if torch_rng:
+            if not isinstance(torch_rng, torch.Generator):
+                raise TypeError('torch_rng must be a torch.Generator object')
+        self.torch_rng = torch_rng
 
     def __repr__(self):
         """String representation of object"""
@@ -69,9 +76,10 @@ class ExpDesigner:
         seed = self.seed
 
         method_dict = {
+            # TODO: botorch is moving to SPEC-0007, `seed` will be phased out in favor of `rng`
             'LHS': lambda d, m: torch.tensor(
                 qmc.LatinHypercube(d=d, scramble=False, seed=seed, strength=1, optimization='random-cd').random(n=m)),
-            'Random': lambda d, m: torch.rand(size=(m, d)),
+            'Random': lambda d, m: torch.rand(size=(m, d), generator=self.torch_rng),
             'Sobol': lambda d, m: draw_sobol_samples(
                 bounds=torch.tensor([0.0, 1.0]).reshape(2, 1).repeat(1, d), n=m, q=1).squeeze(1),
             'Custom': lambda d, m: torch.tensor(sample_custom),
@@ -109,7 +117,7 @@ class ExpDesigner:
             print(f'The number of initialization experiments ({m}) exceeds the required \
                    number for the requested design ({m_required}). Filling with randomized experiments.')
             excess = m - m_required
-            sample_add = torch.rand(size=(excess, d))
+            sample_add = torch.rand(size=(excess, d), generator=self.torch_rng)
             sample = torch.vstack((sample, sample_add))
 
         sample = pd.DataFrame(sample.numpy(), columns=self.X_space.X_names)

--- a/obsidian/experiment/simulator.py
+++ b/obsidian/experiment/simulator.py
@@ -1,5 +1,6 @@
 """Simulate virtual experimental data"""
 
+from types import ModuleType
 from obsidian.parameters import ParamSpace
 
 from typing import Callable
@@ -7,6 +8,8 @@ import pandas as pd
 import numpy as np
 import warnings
 
+from numpy.random import Generator
+import obsidian
 
 class Simulator:
     """
@@ -34,6 +37,7 @@ class Simulator:
                  response_function: Callable,
                  name: str | list[str] = 'Response',
                  eps: float | list[float] = 0.0,
+                 rng: Generator | int | None = None,
                  **kwargs):
         
         if not callable(response_function):
@@ -45,14 +49,28 @@ class Simulator:
         self.response_function = response_function
         self.name = name
         self.eps = eps if isinstance(eps, list) else [eps]
+        if isinstance(rng, Generator):
+            # use provided numpy generator
+            self.rng: Generator | ModuleType = rng
+        else:
+            self._seed = rng
+            if obsidian.USE_OLD_RNG_CONTROL:
+                # no random state control here
+                self.rng = np.random
+            else:
+                # use new global RNG control
+                # note that if the global RNG is already initialized
+                # and the seed (rng) is different, a ValueError will be raised
+                global_rng = obsidian.get_global_rng(rng)
+                self.rng = global_rng.np_rng
         self.kwargs = kwargs
-    
+
     def __repr__(self):
         """String representation of object"""
         return f" obsidian Simulator(response_function={self.response_function.__name__}, eps={self.eps})"
 
     def simulate(self,
-                 X_prop: pd.DataFrame) -> np.ndarray:
+                 X_prop: pd.DataFrame) -> pd.DataFrame:
         """
         Generates a response to a set of experiments.
 
@@ -76,9 +94,10 @@ class Simulator:
             self.eps *= y_sim.ndim
         if y_sim.ndim == 1:
             y_sim = y_sim.reshape(-1, 1)
-        for i in range(y_sim.shape[1]):
-            rel_error = np.random.normal(loc=1, scale=self.eps[i], size=y_sim.shape[0])
-            y_sim[:, i] *= rel_error
+
+        # vectorized operation
+        rel_error = 1 + self.eps * self.rng.normal(size=y_sim.size).reshape(y_sim.shape)
+        y_sim *= rel_error
 
         # Handle naming conventions
         y_dims = y_sim.shape[1]

--- a/obsidian/experiment/simulator.py
+++ b/obsidian/experiment/simulator.py
@@ -1,6 +1,6 @@
 """Simulate virtual experimental data"""
 
-from types import ModuleType
+from types import ModuleType, MethodType
 from obsidian.parameters import ParamSpace
 
 from typing import Callable
@@ -38,6 +38,7 @@ class Simulator:
                  name: str | list[str] = 'Response',
                  eps: float | list[float] = 0.0,
                  rng: Generator | int | None = None,
+                 error_function: Callable | None = None,
                  **kwargs):
         
         if not callable(response_function):
@@ -63,6 +64,10 @@ class Simulator:
                 # and the seed (rng) is different, a ValueError will be raised
                 global_rng = obsidian.get_global_rng(rng)
                 self.rng = global_rng.np_rng
+        if not error_function:
+            self.error_function = self._default_gaussian_error
+        else:
+            self.error_function = MethodType(error_function, self)
         self.kwargs = kwargs
 
     def __repr__(self):
@@ -88,16 +93,14 @@ class Simulator:
         
         y_sim = self.response_function(X)
         
-        # Apply error
         # Expand length of eps to match number of outputs
         if len(self.eps) == 1:
             self.eps *= y_sim.ndim
         if y_sim.ndim == 1:
             y_sim = y_sim.reshape(-1, 1)
 
-        # vectorized operation
-        rel_error = 1 + self.eps * self.rng.normal(size=y_sim.size).reshape(y_sim.shape)
-        y_sim *= rel_error
+        # Apply error
+        y_sim = self.error_function(X, y_sim)
 
         # Handle naming conventions
         y_dims = y_sim.shape[1]
@@ -114,3 +117,7 @@ class Simulator:
         df_sim = pd.DataFrame(y_sim, columns=self.name)
 
         return df_sim
+
+    def _default_gaussian_error(self, X, y_sim: np.ndarray) -> np.ndarray:
+        rel_error = 1 + self.eps * self.rng.normal(size=y_sim.size).reshape(y_sim.shape)
+        return y_sim * rel_error

--- a/obsidian/experiment/simulator.py
+++ b/obsidian/experiment/simulator.py
@@ -1,7 +1,8 @@
 """Simulate virtual experimental data"""
 
-from types import ModuleType, MethodType
+from types import ModuleType
 from obsidian.parameters import ParamSpace
+from obsidian.rng import RNGManager
 
 from typing import Callable
 import pandas as pd
@@ -24,6 +25,14 @@ class Simulator:
         name (str or list[str]): Name of the simulated output(s). Default is ``Response``.
         eps (float or list[float]): The simulated error to apply, as the standard deviation of the Standard
             Normal distribution. Default is ``0``.
+        apply_noise (Callable | None): Optional custom function to apply noise to the simulated response. 
+            If None, uses default multiplicative Gaussian noise. Must have signature::
+        
+                apply_noise(X, y_sim, eps, rng) -> y_with_noise
+                
+            Where X is the input array, y_sim is the noiseless simulation output with shape 
+            (n_samples, n_outputs), eps is the noise parameter array with shape (1, n_eps), 
+            and rng is the numpy random Generator. Must return array with same shape as y_sim.
         kwargs (dict): Optional hyperparameters for the response function.
 
     Raises:
@@ -37,8 +46,8 @@ class Simulator:
                  response_function: Callable,
                  name: str | list[str] = 'Response',
                  eps: float | list[float] = 0.0,
-                 rng: Generator | int | None = None,
-                 error_function: Callable | None = None,
+                 rng: Generator | RNGManager | int | None = None,
+                 apply_noise: Callable | None = None,
                  **kwargs):
         
         if not callable(response_function):
@@ -49,25 +58,37 @@ class Simulator:
         self.X_space = X_space
         self.response_function = response_function
         self.name = name
-        self.eps = eps if isinstance(eps, list) else [eps]
-        if isinstance(rng, Generator):
+        # We always expect `y_sim` to be no more than 2D
+        # `eps` with more than 1D makes no sense
+        # i.e., one error per output dimension or one error for all dimensions, nothing more
+        # Always converting eps to a 2D array for simplicity
+        # numpy broadcasting will handle the rest
+        self.eps = np.atleast_1d(eps)
+        if self.eps.ndim > 1:
+            raise ValueError(f"eps must be scalar or 1D list/array, got {self.eps.ndim}D array")
+        self.eps = self.eps.reshape(1, -1)
+        if isinstance(rng, RNGManager):
+            self.rng: Generator | ModuleType = rng.np_rng
+            self._seed = rng.seed
+        elif isinstance(rng, Generator):
             # use provided numpy generator
-            self.rng: Generator | ModuleType = rng
+            self.rng = rng
+            self._seed = None
         else:
             self._seed = rng
             if obsidian.USE_OLD_RNG_CONTROL:
                 # no random state control here
                 self.rng = np.random
             else:
-                # use new global RNG control
-                # note that if the global RNG is already initialized
-                # and the seed (rng) is different, a ValueError will be raised
-                global_rng = obsidian.get_global_rng(rng)
-                self.rng = global_rng.np_rng
-        if not error_function:
-            self.error_function = self._default_gaussian_error
+                # use new RNG manager to control random state
+                rng = obsidian.create_rng_manager(rng)
+                self.rng = rng.np_rng
+        if not apply_noise:
+            self.apply_noise = self._default_gaussian_noise
         else:
-            self.error_function = MethodType(error_function, self)
+            if not callable(apply_noise):
+                raise TypeError('Error function must be a callable function')
+            self.apply_noise = apply_noise
         self.kwargs = kwargs
 
     def __repr__(self):
@@ -94,13 +115,13 @@ class Simulator:
         y_sim = self.response_function(X)
         
         # Expand length of eps to match number of outputs
-        if len(self.eps) == 1:
-            self.eps *= y_sim.ndim
+        # if len(self.eps) == 1:
+        #     self.eps *= y_sim.ndim
         if y_sim.ndim == 1:
             y_sim = y_sim.reshape(-1, 1)
 
-        # Apply error
-        y_sim = self.error_function(X, y_sim)
+        # Apply noise to the simulated response
+        y_sim = self.apply_noise(X, y_sim, self.eps, self.rng) # type: ignore
 
         # Handle naming conventions
         y_dims = y_sim.shape[1]
@@ -118,6 +139,9 @@ class Simulator:
 
         return df_sim
 
-    def _default_gaussian_error(self, X, y_sim: np.ndarray) -> np.ndarray:
-        rel_error = 1 + self.eps * self.rng.normal(size=y_sim.size).reshape(y_sim.shape)
-        return y_sim * rel_error
+
+    @staticmethod 
+    def _default_gaussian_noise(X: np.ndarray, y_sim: np.ndarray, eps: np.ndarray, rng: Generator) -> np.ndarray:
+        """Default error function - multiplicative Gaussian noise."""
+        rel_noise = 1 + eps * rng.normal(size=y_sim.shape)
+        return y_sim * rel_noise

--- a/obsidian/experiment/simulator.py
+++ b/obsidian/experiment/simulator.py
@@ -139,6 +139,7 @@ class Simulator:
 
         return df_sim
 
+    #TODO: simulator can have its own random state now, so a save and load state method should be implemented in the future.
 
     @staticmethod 
     def _default_gaussian_noise(X: np.ndarray, y_sim: np.ndarray, eps: np.ndarray, rng: Generator) -> np.ndarray:

--- a/obsidian/experiment/utils.py
+++ b/obsidian/experiment/utils.py
@@ -2,13 +2,15 @@
 from obsidian.exceptions import UnsupportedError
 
 import numpy as np
+from numpy.random import Generator
 from itertools import product
+from types import ModuleType
 
 
 def factorial_DOE(d: int,
                   n_CP: int = 3,
                   shuffle: bool = True,
-                  seed: int | None = None,
+                  seed: Generator | int | None = None,
                   full: bool = False):
     """
     Creates a statistically designed factorial experiment (DOE).
@@ -22,7 +24,7 @@ def factorial_DOE(d: int,
             uncertainty and curvature. Default is ``3``.
         shuffle (bool, optional): Whether or not to shuffle the design or leave them in the default run
             order. Default is ``True``.
-        seed (int, optional): Randomization seed. Default is ``None``.
+        seed (Generator | int | None, optional): Randomization seed or generator for numpy. Default is ``None``.
         full (bool, optional): Whether or not to run the full DOE. Default is ``False``, which
             will lead to an efficient Res4+ design.
 
@@ -72,10 +74,17 @@ def factorial_DOE(d: int,
     
     # Add centerpoints then shuffle
     X = np.vstack((X, CP))
-    if seed is not None:
-        np.random.seed(seed)
+    if isinstance(seed, Generator):
+        # if it is actually a generator
+        rng: Generator | ModuleType = seed
+    else:
+        # with or without a seed, we use np.random for now
+        # in the future, we should instantiate a new random generator from entropy
+        rng = np.random
+        if seed is not None:
+            np.random.seed(seed)
     if shuffle:
-        np.random.shuffle(X)
+        rng.shuffle(X)
     # Rescale from (-1,1) to (0,0.999999)
     X = (X+1)/2 - 1e-6
     

--- a/obsidian/optimizer/base.py
+++ b/obsidian/optimizer/base.py
@@ -46,14 +46,13 @@ class Optimizer(ABC):
         self.verbose = verbose
 
         # Handle randomization seed, considering all 3 sources (torch, random, numpy)
-        self.seed = seed
         # TODO: this part is only for backward compatibility, we should drop it eventually
         if obsidian.USE_OLD_RNG_CONTROL:
-            if self.seed is not None:
-                torch.manual_seed(self.seed)
+            if seed is not None:
+                torch.manual_seed(seed)
                 torch.use_deterministic_algorithms(True)
-                np.random.seed(self.seed)
-                random.seed(self.seed)
+                np.random.seed(seed)
+                random.seed(seed)
             self.torch_rng = None
         else:
             if not rng:
@@ -62,18 +61,20 @@ class Optimizer(ABC):
                 raise TypeError('rng must be an instance of RNGManager')
             else:
                 self.rng = rng
+            seed = self.rng.seed
             self.torch_rng = self.rng.torch_rng
             
             # Create dedicated generator for model operations (fit & suggest)
             # This ensures reproducibility - same initial state gives same seed sequence
             if seed is None:
-                self.seed: int = get_new_seed(1, self.torch_rng) # type: ignore
+                seed: int = get_new_seed(1, self.torch_rng) # type: ignore
             if fix_random_state:
                 self.model_generator = None
             else:
-                self.model_generator = create_torch_rng(self.seed)
+                self.model_generator = create_torch_rng(seed)
             self.fix_random_state = fix_random_state
 
+        self.seed = seed
         # Store the parameter space which contains useful reference properties
         if not isinstance(X_space, ParamSpace):
             raise TypeError('X_space must be an obsidian ParamSpace object')

--- a/obsidian/optimizer/base.py
+++ b/obsidian/optimizer/base.py
@@ -1,5 +1,6 @@
 """Optimizer class definition"""
 
+import obsidian
 from obsidian.parameters import ParamSpace, Target, Param_Observational
 from obsidian.exceptions import UnsupportedError
 
@@ -12,6 +13,8 @@ import numpy as np
 import torch
 import random
 from torch import Tensor
+
+from obsidian.rng import GlobalRNG, dummy_decorator
 
 
 class Optimizer(ABC):
@@ -32,6 +35,7 @@ class Optimizer(ABC):
     def __init__(self,
                  X_space: ParamSpace,
                  seed: int | None = None,
+                 global_rng: GlobalRNG | None = None,
                  verbose: int = 1):
         
         # Verbose selection
@@ -42,11 +46,26 @@ class Optimizer(ABC):
 
         # Handle randomization seed, considering all 3 sources (torch, random, numpy)
         self.seed = seed
-        if self.seed is not None:
-            torch.manual_seed(self.seed)
-            torch.use_deterministic_algorithms(True)
-            np.random.seed(self.seed)
-            random.seed(self.seed)
+        # TODO: this part is only for backward compatibility, we should drop it eventually
+        if obsidian.USE_OLD_RNG_CONTROL:
+            if self.seed is not None:
+                torch.manual_seed(self.seed)
+                torch.use_deterministic_algorithms(True)
+                np.random.seed(self.seed)
+                random.seed(self.seed)
+            self.rng_decorator = dummy_decorator
+            self.fit = self.rng_decorator(self.fit)
+            self.torch_rng = None
+        else:
+            if not global_rng:
+                self.global_rng = obsidian.get_global_rng(seed)
+            elif not isinstance(global_rng, GlobalRNG):
+                raise TypeError('global_rng must be an instance of GlobalRNG')
+            else:
+                self.global_rng = global_rng
+            self.torch_rng = self.global_rng.torch_rng
+            self.rng_decorator = self.global_rng.tmp_seed_override
+            self.fit = self.rng_decorator(self.fit)
 
         # Store the parameter space which contains useful reference properties
         if not isinstance(X_space, ParamSpace):
@@ -217,9 +236,7 @@ class Optimizer(ABC):
         return min_distance
 
     @abstractmethod
-    def fit(self,
-            Z: pd.DataFrame,
-            target: Target | list[Target]):
+    def fit(self, Z: pd.DataFrame, target: Target | list[Target], fit_options: dict):
         """Fit the optimizer's surrogate models to data"""
         pass  # pragma: no cover
 

--- a/obsidian/optimizer/base.py
+++ b/obsidian/optimizer/base.py
@@ -14,7 +14,7 @@ import torch
 import random
 from torch import Tensor
 
-from obsidian.rng import GlobalRNG, dummy_decorator
+from obsidian.rng import RNGManager, get_new_seed, create_torch_rng
 
 
 class Optimizer(ABC):
@@ -35,11 +35,12 @@ class Optimizer(ABC):
     def __init__(self,
                  X_space: ParamSpace,
                  seed: int | None = None,
-                 global_rng: GlobalRNG | None = None,
+                 rng: RNGManager | None = None,
+                 fix_random_state: bool = True,
                  verbose: int = 1):
         
         # Verbose selection
-        if verbose not in [0, 1, 2, 3]:
+        if verbose not in {0, 1, 2, 3}:
             raise ValueError('Verbose option must be 0 (no output), 1 (summary output), \
                              2 (detailed output), or 3 (debugging)')
         self.verbose = verbose
@@ -53,19 +54,25 @@ class Optimizer(ABC):
                 torch.use_deterministic_algorithms(True)
                 np.random.seed(self.seed)
                 random.seed(self.seed)
-            self.rng_decorator = dummy_decorator
-            self.fit = self.rng_decorator(self.fit)
             self.torch_rng = None
         else:
-            if not global_rng:
-                self.global_rng = obsidian.get_global_rng(seed)
-            elif not isinstance(global_rng, GlobalRNG):
-                raise TypeError('global_rng must be an instance of GlobalRNG')
+            if not rng:
+                self.rng = obsidian.create_rng_manager(seed)
+            elif not isinstance(rng, RNGManager):
+                raise TypeError('rng must be an instance of RNGManager')
             else:
-                self.global_rng = global_rng
-            self.torch_rng = self.global_rng.torch_rng
-            self.rng_decorator = self.global_rng.tmp_seed_override
-            self.fit = self.rng_decorator(self.fit)
+                self.rng = rng
+            self.torch_rng = self.rng.torch_rng
+            
+            # Create dedicated generator for model operations (fit & suggest)
+            # This ensures reproducibility - same initial state gives same seed sequence
+            if seed is None:
+                self.seed: int = get_new_seed(1, self.torch_rng) # type: ignore
+            if fix_random_state:
+                self.model_generator = None
+            else:
+                self.model_generator = create_torch_rng(self.seed)
+            self.fix_random_state = fix_random_state
 
         # Store the parameter space which contains useful reference properties
         if not isinstance(X_space, ParamSpace):
@@ -235,9 +242,33 @@ class Optimizer(ABC):
         
         return min_distance
 
+    def fit(self, Z: pd.DataFrame, target: Target | list[Target], manual_seed: int | None = None, fit_options: dict = {}):
+        """Fit surrogate model(s) using observed data.
+
+        This is a wrapper around :meth:`_fit` that handles RNG behavior for
+        backward compatibility:
+        - If ``obsidian.USE_OLD_RNG_CONTROL`` is ``True``, calls ``_fit`` directly.
+        - Otherwise, temporarily applies ``manual_seed`` via ``tmp_seed_override`` and
+          then calls ``_fit``.
+
+        Args:
+            Z (pd.DataFrame): Observation table containing input variables and
+                measured target values used for training.
+            target (Target | list[Target]): One target or a list of targets to fit.
+            manual_seed (int | None, optional): Temporary seed used only for this fit call when new RNG control is
+                enabled. If ``None``, a seed is sampled from the optimizer's model_generator. Defaults to ``None``.
+            fit_options (dict, optional): Extra options forwarded to model.fit(). Refer to model's ``fit`` method for
+                supported options. Defaults to an empty dictionary.
+
+        Returns:
+            None: Fit the surrogate model(s) in-place.
+        """
+        fit_with_seed = self._rng_wrapper(self._fit, manual_seed)
+        return fit_with_seed(Z, target, fit_options)
+
     @abstractmethod
-    def fit(self, Z: pd.DataFrame, target: Target | list[Target], fit_options: dict):
-        """Fit the optimizer's surrogate models to data"""
+    def _fit(self, Z: pd.DataFrame, target: Target | list[Target], fit_options: dict) -> None:
+        """Actual method to fit the optimizer's surrogate models to data"""
         pass  # pragma: no cover
 
     @abstractmethod
@@ -259,13 +290,39 @@ class Optimizer(ABC):
         pass  # pragma: no cover
 
     @abstractmethod
-    def save_state(self):
+    def save_state(self) -> dict:
         """Save the optimizer to a state dictionary"""
         pass  # pragma: no cover
     
     @classmethod
     @abstractmethod
-    def load_state(cls,
-                   obj_dict: dict):
+    def load_state(cls, obj_dict: dict):
         """Load the optimizer from a state dictionary"""
         pass  # pragma: no cover
+
+    def _rng_wrapper(self, func, manual_seed: int | None = None):
+        """
+        Helper to apply RNG seeding control to a function call.
+    
+        Consolidates the seed selection logic (manual_seed > model_generator > self.seed)
+        and applies tmp_seed_override for backward compatibility with USE_OLD_RNG_CONTROL.
+    
+        Args:
+            func: Function to wrap with RNG control
+            manual_seed: Optional manual seed override
+    
+        Returns:
+            Wrapped function ready to be called
+        """
+        if obsidian.USE_OLD_RNG_CONTROL:
+            return func
+        else:
+            # Seed priority: manual_seed > model_generator > self.seed
+            if manual_seed is not None:
+                seed = manual_seed
+            elif self.model_generator:
+                seed = get_new_seed(1, self.model_generator)
+            else:
+                seed = self.seed
+
+            return self.rng.tmp_seed_override(func, seed)  # type: ignore

--- a/obsidian/optimizer/bayesian.py
+++ b/obsidian/optimizer/bayesian.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 import obsidian
-from obsidian.rng import GlobalRNG
+from obsidian.rng import RNGManager, create_torch_rng, get_new_seed
 from .base import Optimizer
 
 from obsidian.parameters import ParamSpace, Target, Task
@@ -80,10 +80,11 @@ class BayesianOptimizer(Optimizer):
                  X_space: ParamSpace,
                  surrogate: str | dict | list[str] | list[dict] = 'GP',
                  seed: int | None = None,
-                 global_rng: GlobalRNG | None = None,
+                 rng: RNGManager | None = None,
+                 fix_random_state: bool = True,
                  verbose: int = 1):
-       
-        super().__init__(X_space=X_space, seed=seed, global_rng=global_rng, verbose=verbose)
+
+        super().__init__(X_space=X_space, seed=seed, rng=rng, fix_random_state=fix_random_state, verbose=verbose)
 
         self.surrogate_type = []  # Shorthand name as str (as provided)
         self.surrogate_hps = []  # Hyperparameters
@@ -170,9 +171,10 @@ class BayesianOptimizer(Optimizer):
                     raise TypeError('Each item in target must be a Target object')
         return target
 
-    def fit(self, Z: pd.DataFrame, target: Target | list[Target], fit_options: dict = {}):
+    def _fit(self, Z: pd.DataFrame, target: Target | list[Target], fit_options: dict = {}):
         """
-        Fits the BO surrogate model to data.
+        Fits the BO surrogate model to data. The user-facing ``fit`` method is inherited from the base Optimizer class,
+        which handles RNG control and then calls this method to perform the actual fitting.
 
         Args:
             Z (pd.DataFrame): Total dataset including inputs (X) and response values (y)
@@ -226,48 +228,40 @@ class BayesianOptimizer(Optimizer):
 
         # Instantiate and fit the model(s)
         self.surrogate = []
-        # with USE_OLD_RNG_CONTROL, this decorator is dummy
-        # otherwise the decorator will activate a context manager to temporarily set the RNG seeds
-        @self.rng_decorator
-        def fit_models():
-            """A wrapper switching between new (context manager) and old (manual) RNG behavior."""
-            for i in range(self.n_response):
-                model = SurrogateBoTorch(
-                    model_type=self.surrogate_type[i],
-                    seed=self.seed,
-                    verbose=self.verbose >= 2,
-                    hps=self.surrogate_hps[i],
-                )
+        for i in range(self.n_response):
+            model = SurrogateBoTorch(
+                model_type=self.surrogate_type[i],
+                seed=self.seed,
+                verbose=self.verbose >= 2,
+                hps=self.surrogate_hps[i],
+            )
 
-                # Handle response NaN values on a response-by-response basis
-                f_train_i = self.f_train.iloc[:, i]
-                nan_indices = np.where(f_train_i.isna().values)[0]
-                X_t_train_valid = self.X_t_train.drop(nan_indices)
-                f_train_i_valid = f_train_i.drop(nan_indices)
-                if X_t_train_valid.shape[0] < 1:
-                    raise ValueError(f'No valid data points for response {self.y_names[i]}')
-                if f_train_i_valid.shape[0] < 1:
-                    raise ValueError(f'No valid response data points for response {self.y_names[i]}')
+            # Handle response NaN values on a response-by-response basis
+            f_train_i = self.f_train.iloc[:, i]
+            nan_indices = np.where(f_train_i.isna().values)[0]
+            X_t_train_valid = self.X_t_train.drop(nan_indices)
+            f_train_i_valid = f_train_i.drop(nan_indices)
+            if X_t_train_valid.shape[0] < 1:
+                raise ValueError(f'No valid data points for response {self.y_names[i]}')
+            if f_train_i_valid.shape[0] < 1:
+                raise ValueError(f'No valid response data points for response {self.y_names[i]}')
 
-                # Fit the model for each response
-                model.fit(
-                    X_t_train_valid,
-                    f_train_i_valid,
-                    cat_dims=self.X_space.X_t_cat_idx,
-                    task_feature=self.X_space.X_t_task_idx,
-                    **fit_options,
-                )
+            # Fit the model for each response
+            model.fit(
+                X_t_train_valid,
+                f_train_i_valid,
+                cat_dims=self.X_space.X_t_cat_idx,
+                task_feature=self.X_space.X_t_task_idx,
+                **fit_options,
+            )
 
-                if self.verbose >= 1:
-                    print(f'{self.surrogate_type[i]} model has been fit to data'
-                          + f' with an R2-train-score of: {model.r2_score:.3g}'
-                          + (f' and a training-loss of: {model.loss:.3g}' if self.verbose >= 2 else '')
-                          + f' for response: {self.y_names[i]}')
-                self.surrogate.append(model)
-
-        fit_models()
+            if self.verbose >= 1:
+                print(f'{self.surrogate_type[i]} model has been fit to data'
+                      + f' with an R2-train-score of: {model.r2_score:.3g}'
+                      + (f' and a training-loss of: {model.loss:.3g}' if self.verbose >= 2 else '')
+                      + f' for response: {self.y_names[i]}')
+            self.surrogate.append(model)
     
-    # TODO: incorporate new global RNG
     def save_state(self) -> dict:
         """
         Saves the parameters of the Bayesian Optimizer so that they can be reloaded without fitting.
@@ -299,6 +293,13 @@ class BayesianOptimizer(Optimizer):
             else:
                 config_save['opt_attrs'][attr] = getattr(self, attr)
 
+        # Save RNG state if new RNG control is enabled
+        if not obsidian.USE_OLD_RNG_CONTROL:
+            config_save['rng_state'] = self.rng.save_state()
+            config_save['fix_random_state'] = hasattr(self, 'model_generator') and self.model_generator is None
+            if self.model_generator:
+                config_save['model_generator_state'] = self.model_generator.get_state().cpu().tolist()
+
         # Unpack the fit parameters of each surrogate model, if present
         if self.surrogate:
             model_states = []
@@ -313,7 +314,6 @@ class BayesianOptimizer(Optimizer):
     def __repr__(self):
         return f'BayesianOptimizer(X_space={self.X_space}, surrogate={self.surrogate_type}, target={getattr(self, "target", None)})'
 
-    # TODO: incorporate new global RNG
     @classmethod
     def load_state(cls,
                    config_save: dict):
@@ -330,9 +330,26 @@ class BayesianOptimizer(Optimizer):
             ValueError: If the number of saved models does not match the number of named models.
         """
 
+        # Restore RNG state if saved
+        rng = None
+        fix_random_state = True
+        if 'rng_state' in config_save:
+            rng = RNGManager.load_state(config_save['rng_state'])
+            fix_random_state = config_save.get('fix_random_state', True)
+
+        seed = config_save.get('seed', None)
+
         new_opt = cls(X_space=ParamSpace.load_state(config_save['X_space']),
-                      surrogate=config_save['surrogate_spec'])
+                      surrogate=config_save['surrogate_spec'],
+                      seed=seed,
+                      rng=rng,
+                      fix_random_state=fix_random_state)
         new_opt.target = [Target.load_state(t) for t in config_save['target']]
+
+        # Restore model_generator state if saved
+        if 'model_generator_state' in config_save:
+            tmp_rng = create_torch_rng(0)
+            new_opt.model_generator = tmp_rng.set_state(torch.ByteTensor(config_save['model_generator_state']))
 
         # Directly unpack all of the entries in opt_attrs
         for k, v in config_save['opt_attrs'].items():
@@ -613,7 +630,8 @@ class BayesianOptimizer(Optimizer):
                 task_index: int = 0,
                 fixed_var: dict[str: float | str] | None = None,
                 X_pending: pd.DataFrame | None = None,
-                eval_pending: pd.DataFrame | None = None) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+                eval_pending: pd.DataFrame | None = None,
+                manual_seed: int | None = None) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
         """
         Suggest future experiments based on a maximization of some acquisition
         function calculated from the expectation of a surrogate model.
@@ -852,7 +870,6 @@ class BayesianOptimizer(Optimizer):
                                    Setting optim_sequential to False', UserWarning)
                     optim_sequential = False
 
-            @self.rng_decorator
             def optimize_acqf_wrapper(fixed_features_list):
                 if fixed_features_list:
                     # If there are any discrete values, we must used the mixed integer optimization
@@ -865,7 +882,7 @@ class BayesianOptimizer(Optimizer):
                 candidates, _ = optim_func(
                     acq_function=aq_func,
                     bounds=X_bounds,
-                    q=m_batch,  
+                    q=m_batch,
                     num_restarts=optim_restarts,
                     raw_samples=optim_samples,
                     options=optim_options,
@@ -879,7 +896,9 @@ class BayesianOptimizer(Optimizer):
             else:
                 aq_func = aq_class_dict[aq_str](**aq_kwargs).to(TORCH_DTYPE)
 
-                candidates, _ = optimize_acqf_wrapper(fixed_features_list)
+                # Wrap with RNG control
+                wrapped_func = self._rng_wrapper(optimize_acqf_wrapper, manual_seed)
+                candidates, _ = wrapped_func(fixed_features_list)
 
             if self.verbose >= 2:
                 print(f'Optimized {aq_str} acquisition function successfully')

--- a/obsidian/optimizer/bayesian.py
+++ b/obsidian/optimizer/bayesian.py
@@ -337,7 +337,7 @@ class BayesianOptimizer(Optimizer):
             rng = RNGManager.load_state(config_save['rng_state'])
             fix_random_state = config_save.get('fix_random_state', True)
 
-        seed = config_save.get('seed', None)
+        seed = config_save['opt_attrs'].get('seed', None)
 
         new_opt = cls(X_space=ParamSpace.load_state(config_save['X_space']),
                       surrogate=config_save['surrogate_spec'],

--- a/obsidian/optimizer/bayesian.py
+++ b/obsidian/optimizer/bayesian.py
@@ -352,8 +352,6 @@ class BayesianOptimizer(Optimizer):
         Raises:
             ValueError: If the number of saved models does not match the number of named models.
         """
-        import warnings
-
         # Check for is_fitted flag and handle backward compatibility
         if 'is_fitted' in config_save:
             is_fitted = config_save['is_fitted']
@@ -655,6 +653,43 @@ class BayesianOptimizer(Optimizer):
         
         return model, o_dim, target_locs, target
 
+    @property
+    def non_tracking_targets(self) -> list[Target]:
+        """Targets eligible for suggestion (all non-tracking targets)."""
+        return [t for t in self.target if not t.tracking_only]
+
+    def _validate_suggestion_target(
+            self,
+            target: Target | list[Target] | None = None,
+        ) -> list[Target]:
+        """Validate and normalize targets for suggestion-only operations."""
+        if target is None:
+            non_tracking_targets = self.non_tracking_targets
+            if not non_tracking_targets:
+                raise UnsupportedError('No suggestible targets available: all fitted targets are tracking-only')
+            return non_tracking_targets
+
+        target = self._validate_target(target)
+        fitted_targets = {t.name: t for t in self.target}
+        selected_targets: list[Target] = []
+        warned_tracking = set()
+
+        for t in target:
+            if t.name not in fitted_targets:
+                raise NameError(f'Specified target {t.name} is not present in fitted targets')
+
+            target_fit = fitted_targets[t.name]
+            if target_fit.tracking_only and t.name not in warned_tracking:
+                warnings.warn(
+                    f'Target {t.name} is tracking-only and was explicitly requested for suggestion.',
+                    UserWarning,
+                    stacklevel=3,
+                )
+                warned_tracking.add(t.name)
+            selected_targets.append(target_fit)
+
+        return selected_targets
+
     def _setup_constraints(
             self,
             eq_constraints: Linear_Constraint | list[Linear_Constraint] | None,
@@ -870,7 +905,7 @@ class BayesianOptimizer(Optimizer):
 
         Args:
             m_batch (int, optional): The number of experiments to suggest at once. The default is ``1``.
-            target (Target or list of Target, optional): The response(s) to be used for optimization,
+            target (Target or list of Target, optional): The response(s) to be used for optimization.
             acquisition (list of str or list of dict, optional): Indicator for the desired acquisition function(s).
                 A list will propose experiments for each acquisition function based on ``optim_sequential``.
                 
@@ -943,6 +978,8 @@ class BayesianOptimizer(Optimizer):
         
         if self.verbose >= 2:
             print(f'Optimizing {m_batch} experiments [...]')
+
+        target = self._validate_suggestion_target(target)
         
         # Setup model and objective
         model, o_dim, target_locs, target = self._setup_model_and_objective(target, objective)
@@ -1150,6 +1187,7 @@ class BayesianOptimizer(Optimizer):
         return eval_suggest
 
     def maximize(self,
+                 acquisition=['Mean'],
                  optim_samples=1026,
                  optim_restarts=50,
                  fixed_var: dict[str, float | str] | None = None) -> tuple[pd.DataFrame, pd.DataFrame]:
@@ -1172,12 +1210,19 @@ class BayesianOptimizer(Optimizer):
         X_suggest = pd.DataFrame()
         eval_suggest = pd.DataFrame()
 
-        for target in self.target:
-            X_suggest_i, eval_suggest_i = self.suggest(
-                m_batch=1, acquisition=['Mean'], optim_samples=optim_samples, optim_restarts=optim_restarts,
-                target=target, fixed_var=fixed_var)
-            X_suggest = pd.concat([X_suggest, X_suggest_i], axis=0)
-            eval_suggest = pd.concat([eval_suggest, eval_suggest_i], axis=0)
+        # Maximize intentionally evaluates all targets, so suppress tracking-only warnings in suggest
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore',
+                message=r'Target .* is tracking-only and was explicitly requested for suggestion\.',
+                category=UserWarning,
+            )
+            for target in self.target:
+                X_suggest_i, eval_suggest_i = self.suggest(
+                    m_batch=1, acquisition=acquisition, optim_samples=optim_samples, optim_restarts=optim_restarts,
+                    target=target, fixed_var=fixed_var)
+                X_suggest = pd.concat([X_suggest, X_suggest_i], axis=0)
+                eval_suggest = pd.concat([eval_suggest, eval_suggest_i], axis=0)
         
         return X_suggest, eval_suggest
 

--- a/obsidian/optimizer/bayesian.py
+++ b/obsidian/optimizer/bayesian.py
@@ -857,6 +857,7 @@ class BayesianOptimizer(Optimizer):
                 if fixed_features_list:
                     # If there are any discrete values, we must used the mixed integer optimization
                     optim_func = optimize_acqf_mixed
+                    optim_kwargs["fixed_features_list"] = fixed_features_list
                 else:
                     optim_func = optimize_acqf
                     optim_kwargs["sequential"] = optim_sequential
@@ -864,7 +865,6 @@ class BayesianOptimizer(Optimizer):
                 candidates, _ = optim_func(
                     acq_function=aq_func,
                     bounds=X_bounds,
-                    fixed_features_list=fixed_features_list,
                     q=m_batch,  
                     num_restarts=optim_restarts,
                     raw_samples=optim_samples,

--- a/obsidian/optimizer/bayesian.py
+++ b/obsidian/optimizer/bayesian.py
@@ -1,5 +1,8 @@
 """Bayesian Optimization: Select experiments from the predicted posterior and update the prior"""
 
+from typing import Any
+import obsidian
+from obsidian.rng import GlobalRNG
 from .base import Optimizer
 
 from obsidian.parameters import ParamSpace, Target, Task
@@ -28,8 +31,6 @@ import pandas as pd
 import numpy as np
 import warnings
 
-UNIQUE_SEEDS = False
-UNIQUE_SEEDS_SAMPLER = False
 
 class BayesianOptimizer(Optimizer):
     """
@@ -79,16 +80,10 @@ class BayesianOptimizer(Optimizer):
                  X_space: ParamSpace,
                  surrogate: str | dict | list[str] | list[dict] = 'GP',
                  seed: int | None = None,
+                 global_rng: GlobalRNG | None = None,
                  verbose: int = 1):
        
-        super().__init__(X_space=X_space, seed=seed, verbose=verbose)
-        print("  Optimizer seed", seed)
-
-        if UNIQUE_SEEDS:
-            if seed is not None:
-                self.optimizer_rng = torch.Generator().manual_seed(seed)
-            else:
-                self.optimizer_rng = torch.Generator()
+        super().__init__(X_space=X_space, seed=seed, global_rng=global_rng, verbose=verbose)
 
         self.surrogate_type = []  # Shorthand name as str (as provided)
         self.surrogate_hps = []  # Hyperparameters
@@ -130,8 +125,7 @@ class BayesianOptimizer(Optimizer):
             if surrogate_str not in model_class_dict.keys():
                 raise KeyError(f'Surrogate model must be selected from one of: {model_class_dict.keys()}')
 
-        return
-    
+
     @property
     def is_fit(self):
         """
@@ -176,9 +170,7 @@ class BayesianOptimizer(Optimizer):
                     raise TypeError('Each item in target must be a Target object')
         return target
 
-    def fit(self,
-            Z: pd.DataFrame,
-            target: Target | list[Target]):
+    def fit(self, Z: pd.DataFrame, target: Target | list[Target], fit_options: dict = {}):
         """
         Fits the BO surrogate model to data.
 
@@ -186,6 +178,7 @@ class BayesianOptimizer(Optimizer):
             Z (pd.DataFrame): Total dataset including inputs (X) and response values (y)
             target (Target or list of Target): The responses (y) to be used for optimization,
                 packed into a Target object or list thereof
+            fit_options (dict, optional): Additional options to customize the fitting process. Refer to the model's `fit` method for details.
 
         Returns:
             None. Updates the model in self.surrogate
@@ -232,38 +225,49 @@ class BayesianOptimizer(Optimizer):
         self.X_best_f = self.X_train.iloc[self.X_best_f_idx, :].to_frame().T
 
         # Instantiate and fit the model(s)
-        if UNIQUE_SEEDS:
-            model_seed = torch.randint(0, 1_000_000, (1,), generator=self.optimizer_rng).item()
-        else:
-            model_seed = self.seed
-        print("    Model seed", model_seed)
         self.surrogate = []
-        for i in range(self.n_response):
-            self.surrogate.append(
-                SurrogateBoTorch(model_type=self.surrogate_type[i], seed=model_seed,
-                                 verbose=self.verbose >= 2, hps=self.surrogate_hps[i]))
-            
-            # Handle response NaN values on a response-by-response basis
-            f_train_i = self.f_train.iloc[:, i]
-            nan_indices = np.where(f_train_i.isna().values)[0]
-            X_t_train_valid = self.X_t_train.drop(nan_indices)
-            f_train_i_valid = f_train_i.drop(nan_indices)
-            if X_t_train_valid.shape[0] < 1:
-                raise ValueError(f'No valid data points for response {self.y_names[i]}')
-            if f_train_i_valid.shape[0] < 1:
-                raise ValueError(f'No valid response data points for response {self.y_names[i]}')
-            
-            # Fit the model for each response
-            self.surrogate[i].fit(X_t_train_valid, f_train_i_valid,
-                                  cat_dims=self.X_space.X_t_cat_idx, task_feature=self.X_space.X_t_task_idx)
-            
-            if self.verbose >= 1:
-                print(f'{self.surrogate_type[i]} model has been fit to data'
-                      + f' with an R2-train-score of: {self.surrogate[i].r2_score:.3g}'
-                      + (f' and a training-loss of: {self.surrogate[i].loss:.3g}' if self.verbose >= 2 else '')
-                      + f' for response: {self.y_names[i]}')
-        return
+        # with USE_OLD_RNG_CONTROL, this decorator is dummy
+        # otherwise the decorator will activate a context manager to temporarily set the RNG seeds
+        @self.rng_decorator
+        def fit_models():
+            """A wrapper switching between new (context manager) and old (manual) RNG behavior."""
+            for i in range(self.n_response):
+                model = SurrogateBoTorch(
+                    model_type=self.surrogate_type[i],
+                    seed=self.seed,
+                    verbose=self.verbose >= 2,
+                    hps=self.surrogate_hps[i],
+                )
+
+                # Handle response NaN values on a response-by-response basis
+                f_train_i = self.f_train.iloc[:, i]
+                nan_indices = np.where(f_train_i.isna().values)[0]
+                X_t_train_valid = self.X_t_train.drop(nan_indices)
+                f_train_i_valid = f_train_i.drop(nan_indices)
+                if X_t_train_valid.shape[0] < 1:
+                    raise ValueError(f'No valid data points for response {self.y_names[i]}')
+                if f_train_i_valid.shape[0] < 1:
+                    raise ValueError(f'No valid response data points for response {self.y_names[i]}')
+
+                # Fit the model for each response
+                model.fit(
+                    X_t_train_valid,
+                    f_train_i_valid,
+                    cat_dims=self.X_space.X_t_cat_idx,
+                    task_feature=self.X_space.X_t_task_idx,
+                    **fit_options,
+                )
+
+                if self.verbose >= 1:
+                    print(f'{self.surrogate_type[i]} model has been fit to data'
+                          + f' with an R2-train-score of: {model.r2_score:.3g}'
+                          + (f' and a training-loss of: {model.loss:.3g}' if self.verbose >= 2 else '')
+                          + f' for response: {self.y_names[i]}')
+                self.surrogate.append(model)
+
+        fit_models()
     
+    # TODO: incorporate new global RNG
     def save_state(self) -> dict:
         """
         Saves the parameters of the Bayesian Optimizer so that they can be reloaded without fitting.
@@ -309,6 +313,7 @@ class BayesianOptimizer(Optimizer):
     def __repr__(self):
         return f'BayesianOptimizer(X_space={self.X_space}, surrogate={self.surrogate_type}, target={getattr(self, "target", None)})'
 
+    # TODO: incorporate new global RNG
     @classmethod
     def load_state(cls,
                    config_save: dict):
@@ -599,6 +604,7 @@ class BayesianOptimizer(Optimizer):
                 optim_sequential: bool = True,
                 optim_samples: int = 512,
                 optim_restarts: int = 10,
+                optim_options: dict | None = None,
                 objective: MCAcquisitionObjective | None = None,
                 out_constraints: Output_Constraint | list[Output_Constraint] | None = None,
                 eq_constraints: Linear_Constraint | list[Linear_Constraint] | None = None,
@@ -650,6 +656,7 @@ class BayesianOptimizer(Optimizer):
                 The default value is ``512``.
             optim_restarts (int, optional): The number of restarts to use in the global optimization
                 of the acquisition function. The default value is ``10``.
+            optim_options (dict, optional): Options to pass to the optimization routine directly. Refer to BoTorch's `optimize_acqf` function family, `gen_candidates_scipy`, `gen_candidates_torch`, and `scipy.optimize.minimize` for possible options.
             objective (MCAcquisitionObjective, optional): The objective function to be used for optimization.
                 The default is ``None``.
             out_constraints (Output_Constraint | list[Output_Constraint], optional): An output constraint, or a list
@@ -733,21 +740,17 @@ class BayesianOptimizer(Optimizer):
                           + ' Recommend reducing the number of discrete parameters used.', OptimizerWarning)
         
         # Set up the sampler, for MC-based optimization of acquisition functions
-        if UNIQUE_SEEDS_SAMPLER:
-            sampler_seed = torch.randint(0, 1_000_000, (1,), generator=self.optimizer_rng).item()
-        else:
-            sampler_seed = self.seed
         if not isinstance(model, ModelListGP):
             samplers = []
             for m in model.models:
                 if isinstance(m, EnsembleModel):
-                    sampler_i = IndexSampler(sample_shape=torch.Size([optim_samples]), seed=sampler_seed)
+                    sampler_i = IndexSampler(sample_shape=torch.Size([optim_samples]), seed=self.seed)
                 else:
-                    sampler_i = SobolQMCNormalSampler(sample_shape=torch.Size([optim_samples]), seed=sampler_seed)
+                    sampler_i = SobolQMCNormalSampler(sample_shape=torch.Size([optim_samples]), seed=self.seed)
                 samplers.append(sampler_i)
             sampler = ListSampler(*samplers)
         else:
-            sampler = SobolQMCNormalSampler(sample_shape=torch.Size([optim_samples]), seed=sampler_seed)
+            sampler = SobolQMCNormalSampler(sample_shape=torch.Size([optim_samples]), seed=self.seed)
 
         # Calculate search bounds for optimization
         X_bounds = torch.tensor(self.X_space.search_space.values, dtype=TORCH_DTYPE)
@@ -826,16 +829,18 @@ class BayesianOptimizer(Optimizer):
                 nleq_constraints += self.X_space.nonlinear_constraints
 
             # Input constraints are used by optim_acqf and friends
-            optim_kwargs = {'equality_constraints': [c() for c in eq_constraints] if eq_constraints else None,
-                            'inequality_constraints': [c() for c in ineq_constraints] if ineq_constraints else None,
-                            'nonlinear_inequality_constraints': [c() for c in nleq_constraints] if nleq_constraints else None}
+            optim_kwargs: dict[str, Any] = {
+                "equality_constraints": [c() for c in eq_constraints] if eq_constraints else None,
+                "inequality_constraints": [c() for c in ineq_constraints] if ineq_constraints else None,
+                "nonlinear_inequality_constraints": [c() for c in nleq_constraints] if nleq_constraints else None,
+            }
             
-            optim_options = {}  # Can optionally specify batch_limit or max_iter
+            # optim_options = {}  # Can optionally specify batch_limit or max_iter
             
             # If nonlinear constraints are used, BoTorch doesn't provide an ic_generator
             # Must provide manual samples = just use random initialization
             if nleq_constraints:
-                X_ic = torch.ones((optim_samples, 1 if fixed_features_list else m_batch, self.X_space.n_tdim))*torch.rand(1)
+                X_ic = torch.ones((optim_samples, 1 if fixed_features_list else m_batch, self.X_space.n_tdim))*torch.rand(1, generator=self.torch_rng)
                 optim_kwargs['batch_initial_conditions'] = X_ic
                 if fixed_features_list:
                     raise UnsupportedError('Nonlinear constraints are not supported with discrete features.')
@@ -847,28 +852,35 @@ class BayesianOptimizer(Optimizer):
                                    Setting optim_sequential to False', UserWarning)
                     optim_sequential = False
 
+            @self.rng_decorator
+            def optimize_acqf_wrapper(fixed_features_list):
+                if fixed_features_list:
+                    # If there are any discrete values, we must used the mixed integer optimization
+                    optim_func = optimize_acqf_mixed
+                else:
+                    optim_func = optimize_acqf
+                    optim_kwargs["sequential"] = optim_sequential
+
+                candidates, _ = optim_func(
+                    acq_function=aq_func,
+                    bounds=X_bounds,
+                    fixed_features_list=fixed_features_list,
+                    q=m_batch,  
+                    num_restarts=optim_restarts,
+                    raw_samples=optim_samples,
+                    options=optim_options,
+                    **optim_kwargs,
+                )
+                return candidates, _
+
             # If it's random search, no need to do optimization; Otherwise, initialize the aq function and optimize
             if aq_str == 'RS':
-                candidates = torch.rand((m_batch, self.X_space.n_tdim), dtype=TORCH_DTYPE)
+                candidates = torch.rand((m_batch, self.X_space.n_tdim), generator=self.torch_rng, dtype=TORCH_DTYPE)
             else:
                 aq_func = aq_class_dict[aq_str](**aq_kwargs).to(TORCH_DTYPE)
-                
-                # If there are any discrete values, we must used the mixed integer optimization
-                if fixed_features_list:
-                    candidates, _ = optimize_acqf_mixed(acq_function=aq_func, bounds=X_bounds,
-                                                        fixed_features_list=fixed_features_list,
-                                                        q=m_batch,  # Always sequential
-                                                        num_restarts=optim_restarts, raw_samples=optim_samples,
-                                                        options=optim_options,
-                                                        **optim_kwargs)
-                else:
-                    candidates, _ = optimize_acqf(acq_function=aq_func, bounds=X_bounds,
-                                                  q=m_batch,
-                                                  sequential=optim_sequential,
-                                                  num_restarts=optim_restarts, raw_samples=optim_samples,
-                                                  options=optim_options,
-                                                  **optim_kwargs)
-            
+
+                candidates, _ = optimize_acqf_wrapper(fixed_features_list)
+
             if self.verbose >= 2:
                 print(f'Optimized {aq_str} acquisition function successfully')
             

--- a/obsidian/optimizer/bayesian.py
+++ b/obsidian/optimizer/bayesian.py
@@ -491,7 +491,7 @@ class BayesianOptimizer(Optimizer):
             target_locs (list[int]): Indices of trained targets to use for objective function
             X_t_pending (Tensor, optional): Suggested points yet to be run
             objective (GenericMCMultiOutputObjective or GenericMCObjective, optional):
-                The objective used foroptimization after calling the target models.
+                The objective used for optimization after calling the target models.
                 Default is ``None``.
 
         Returns:

--- a/obsidian/optimizer/bayesian.py
+++ b/obsidian/optimizer/bayesian.py
@@ -3,7 +3,7 @@
 from typing import Any
 import obsidian
 from obsidian.acquisition.utils import ParserContext
-from obsidian.rng import RNGManager, create_torch_rng, get_new_seed
+from obsidian.rng import RNGManager, create_torch_rng
 from obsidian.utils import TaskType
 from .base import Optimizer
 
@@ -24,8 +24,6 @@ from botorch.sampling.index_sampler import IndexSampler
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.gpytorch import GPyTorchModel
 from botorch.models.model import ModelList, Model
-from botorch.utils.sampling import draw_sobol_samples
-from botorch.utils.multi_objective.box_decompositions.non_dominated import NondominatedPartitioning
 
 import torch
 from torch import Tensor
@@ -271,37 +269,42 @@ class BayesianOptimizer(Optimizer):
 
     def save_state(self) -> dict:
         """
-        Saves the parameters of the Bayesian Optimizer so that they can be reloaded without fitting.
+        Saves the parameters of the Bayesian Optimizer so that they can be reloaded.
+
+        This method can save both fitted and unfitted optimizers:
+
+        - **Unfitted**: Saves configuration only (X_space, surrogate spec, RNG state)
+        - **Fitted**: Saves configuration + training data + fitted models
 
         Returns:
-            dict: A dictionary containing the fit parameters for later loading.
-        
-        Raises:
-            UnfitError: If the surrogate model has not been fit before saving the optimizer.
-        """
+            dict: A dictionary containing the optimizer state for later loading.
 
-        if not self.is_fit:
-            raise UnfitError('Surrogate model must be fit before saving optimizer')
+        Examples:
+            >>> # Save unfitted optimizer
+            >>> opt = BayesianOptimizer(X_space, seed=42)
+            >>> state = opt.save_state()  # Works without fitting
+
+            >>> # Load and then fit
+            >>> opt2 = BayesianOptimizer.load_state(state)
+            >>> opt2.fit(data, target=target)
+        """
+        # if not self.is_fit:
+        #     raise UnfitError('Surrogate model must be fit before saving optimizer')
 
         # Prepare a dictionary to describe the state
         config_save = {'opt_attrs': {},
                        'X_space': self.X_space.save_state(),
                        'surrogate_spec': [{func: hps} for func, hps in zip(self.surrogate_type, self.surrogate_hps)],
-                       'target': [t.save_state() for t in self.target]}
+                       'is_fitted': self.is_fit}
 
-        # Select some optimizer attributes to save directly
-        opt_attrs = ['X_train', 'y_train',
-                     'y_names', 'n_response',
-                     'seed', 'X_best_f_idx', 'X_best_f']
-        
-        for attr in opt_attrs:
-            if isinstance(getattr(self, attr), (pd.Series, pd.DataFrame)):
-                config_save['opt_attrs'][attr] = getattr(self, attr).to_dict()
-            else:
-                config_save['opt_attrs'][attr] = getattr(self, attr)
+        # Log if saving unfitted optimizer
+        if not self.is_fit and self.verbose:
+            print("Saving unfitted optimizer (configuration only)")
 
+        # Always save basic attributes
+        config_save['opt_attrs']['seed'] = self.seed
         config_save['opt_attrs']['task'] = self.task.value
-        
+
         # Save RNG state if new RNG control is enabled
         if not obsidian.USE_OLD_RNG_CONTROL:
             config_save['rng_state'] = self.rng.save_state()
@@ -309,13 +312,23 @@ class BayesianOptimizer(Optimizer):
             if self.model_generator:
                 config_save['model_generator_state'] = self.model_generator.get_state().cpu().tolist()
 
-        # Unpack the fit parameters of each surrogate model, if present
-        if self.surrogate:
+        # Conditionally save fit-dependent attributes
+        if self.is_fit:
+            config_save['target'] = [t.save_state() for t in self.target]
+
+            # Select optimizer attributes to save
+            fit_attrs = ['X_train', 'y_train', 'y_names', 'n_response', 'X_best_f_idx', 'X_best_f']
+
+            for attr in fit_attrs:
+                if isinstance(getattr(self, attr), (pd.Series, pd.DataFrame)):
+                    config_save['opt_attrs'][attr] = getattr(self, attr).to_dict()
+                else:
+                    config_save['opt_attrs'][attr] = getattr(self, attr)
+
+            # Save surrogate model states
             model_states = []
-            # Save each surrogate model using surrogate.save() methods
             for surrogate in self.surrogate:
                 model_states.append(surrogate.save_state())
-
             config_save['model_states'] = model_states
 
         return config_save
@@ -326,10 +339,12 @@ class BayesianOptimizer(Optimizer):
     @classmethod
     def load_state(cls, config_save: dict):
         """
-        Loads the parameters of the Bayesian Optimizer from a previously fit optimizer.
+        Loads the parameters of the Bayesian Optimizer from a saved state.
+
+        Can load both fitted and unfitted optimizers.
 
         Args:
-            config_save (dict): A dictionary containing the fit parameters for later loading.
+            config_save (dict): A dictionary containing the saved state.
 
         Returns:
             BayesianOptimizer: Loaded optimizer instance
@@ -337,7 +352,26 @@ class BayesianOptimizer(Optimizer):
         Raises:
             ValueError: If the number of saved models does not match the number of named models.
         """
-        
+        import warnings
+
+        # Check for is_fitted flag and handle backward compatibility
+        if 'is_fitted' in config_save:
+            is_fitted = config_save['is_fitted']
+        else:
+            # Legacy save files: infer from presence of model_states
+            is_fitted = 'model_states' in config_save
+            if is_fitted:
+                # Info message for legacy fitted saves (not a warning, just informational)
+                print("Loading state saved with older version (missing 'is_fitted' flag)")
+
+        # Warn when loading unfitted optimizer
+        if not is_fitted:
+            warnings.warn(
+                "Loading unfitted optimizer - call fit() before making predictions",
+                UserWarning,
+                stacklevel=2
+            )
+
         # Restore RNG state if saved
         rng = None
         fix_random_state = True  # Default
@@ -355,12 +389,15 @@ class BayesianOptimizer(Optimizer):
         if 'model_generator_state' in config_save:
             tmp_rng = create_torch_rng(0)
             new_opt.model_generator = tmp_rng.set_state(torch.ByteTensor(config_save['model_generator_state']))
-        new_opt.target = [Target.load_state(t) for t in config_save['target']]
+
+        # Load target if present (fitted optimizer)
+        if 'target' in config_save:
+            new_opt.target = tuple([Target.load_state(t) for t in config_save['target']])
 
         # Directly unpack all of the entries in opt_attrs
         for k, v in config_save['opt_attrs'].items():
             setattr(new_opt, k, v)
-  
+
         # Unpack and encode/transform the data objects if present
         data_objects = ['X_train', 'y_train', 'X_best_f']
         if all(hasattr(new_opt, attr) for attr in data_objects):
@@ -368,18 +405,18 @@ class BayesianOptimizer(Optimizer):
             new_opt.X_t_train = new_opt.X_space.encode(new_opt.X_train)
             new_opt.y_train = pd.DataFrame(new_opt.y_train, columns=new_opt.y_names)
             new_opt.X_best_f = pd.DataFrame(new_opt.X_best_f)
-            
+
             f_train = pd.DataFrame()
             for t, y in zip(new_opt.target, new_opt.y_train.columns):
                 f = t.transform_f(new_opt.y_train[y], fit=True)
                 f_train = pd.concat([f_train, f.to_frame()], axis=1)
             new_opt.f_train = f_train
-            
+
         # Unpack the models and parameteres if present
         if 'model_states' in config_save:
             if len(new_opt.surrogate_type) != len(config_save['model_states']):
                 raise ValueError('The number of saved models does not match the number of named models')
-            
+
             # Reload each surrogate model using surrogate.load() methods
             new_opt.surrogate = []
             for obj_dict in config_save['model_states']:

--- a/obsidian/optimizer/bayesian.py
+++ b/obsidian/optimizer/bayesian.py
@@ -2,12 +2,14 @@
 
 from typing import Any
 import obsidian
+from obsidian.acquisition.utils import ParserContext
 from obsidian.rng import RNGManager, create_torch_rng, get_new_seed
+from obsidian.utils import TaskType
 from .base import Optimizer
 
 from obsidian.parameters import ParamSpace, Target, Task
 from obsidian.surrogates import SurrogateBoTorch, EnsembleModel
-from obsidian.acquisition import aq_class_dict, aq_defaults, aq_hp_defaults, valid_aqs
+from obsidian.acquisition import registry, aq_defaults, aq_hp_defaults, valid_aqs
 from obsidian.surrogates import model_class_dict
 from obsidian.objectives import Index_Objective, Objective_Sequence
 from obsidian.constraints import Linear_Constraint, Nonlinear_Constraint, Output_Constraint
@@ -79,15 +81,19 @@ class BayesianOptimizer(Optimizer):
     def __init__(self,
                  X_space: ParamSpace,
                  surrogate: str | dict | list[str] | list[dict] = 'GP',
+                 task: TaskType | str = TaskType.OPTIMIZATION,
                  seed: int | None = None,
                  rng: RNGManager | None = None,
                  fix_random_state: bool = True,
                  verbose: int = 1):
-
+       
         super().__init__(X_space=X_space, seed=seed, rng=rng, fix_random_state=fix_random_state, verbose=verbose)
 
         self.surrogate_type = []  # Shorthand name as str (as provided)
         self.surrogate_hps = []  # Hyperparameters
+
+        self.task = TaskType.from_value(task)
+        self.aq_args: dict[str, dict[str, Any]] = {}
 
         # Surrogate model selection
         if not isinstance(surrogate, (str, list, dict)):
@@ -261,7 +267,8 @@ class BayesianOptimizer(Optimizer):
                       + (f' and a training-loss of: {model.loss:.3g}' if self.verbose >= 2 else '')
                       + f' for response: {self.y_names[i]}')
             self.surrogate.append(model)
-    
+
+
     def save_state(self) -> dict:
         """
         Saves the parameters of the Bayesian Optimizer so that they can be reloaded without fitting.
@@ -293,6 +300,8 @@ class BayesianOptimizer(Optimizer):
             else:
                 config_save['opt_attrs'][attr] = getattr(self, attr)
 
+        config_save['opt_attrs']['task'] = self.task.value
+        
         # Save RNG state if new RNG control is enabled
         if not obsidian.USE_OLD_RNG_CONTROL:
             config_save['rng_state'] = self.rng.save_state()
@@ -315,8 +324,7 @@ class BayesianOptimizer(Optimizer):
         return f'BayesianOptimizer(X_space={self.X_space}, surrogate={self.surrogate_type}, target={getattr(self, "target", None)})'
 
     @classmethod
-    def load_state(cls,
-                   config_save: dict):
+    def load_state(cls, config_save: dict):
         """
         Loads the parameters of the Bayesian Optimizer from a previously fit optimizer.
 
@@ -324,19 +332,18 @@ class BayesianOptimizer(Optimizer):
             config_save (dict): A dictionary containing the fit parameters for later loading.
 
         Returns:
-            None. Updates the parameters of the BayesianOptimizer and its surrogate model.
+            BayesianOptimizer: Loaded optimizer instance
 
         Raises:
             ValueError: If the number of saved models does not match the number of named models.
         """
-
+        
         # Restore RNG state if saved
         rng = None
-        fix_random_state = True
+        fix_random_state = True  # Default
         if 'rng_state' in config_save:
             rng = RNGManager.load_state(config_save['rng_state'])
             fix_random_state = config_save.get('fix_random_state', True)
-
         seed = config_save.get('seed', None)
 
         new_opt = cls(X_space=ParamSpace.load_state(config_save['X_space']),
@@ -344,12 +351,10 @@ class BayesianOptimizer(Optimizer):
                       seed=seed,
                       rng=rng,
                       fix_random_state=fix_random_state)
-        new_opt.target = [Target.load_state(t) for t in config_save['target']]
-
-        # Restore model_generator state if saved
         if 'model_generator_state' in config_save:
             tmp_rng = create_torch_rng(0)
             new_opt.model_generator = tmp_rng.set_state(torch.ByteTensor(config_save['model_generator_state']))
+        new_opt.target = [Target.load_state(t) for t in config_save['target']]
 
         # Directly unpack all of the entries in opt_attrs
         for k, v in config_save['opt_attrs'].items():
@@ -378,7 +383,9 @@ class BayesianOptimizer(Optimizer):
             new_opt.surrogate = []
             for obj_dict in config_save['model_states']:
                 new_opt.surrogate.append(SurrogateBoTorch.load_state(obj_dict))
-        
+
+        new_opt.task = TaskType.from_value(new_opt.task)
+
         return new_opt
     
     def predict(self,
@@ -447,6 +454,43 @@ class BayesianOptimizer(Optimizer):
             preds = pd.concat([preds, predict_i], axis=1)
             
         return preds
+
+    def _build_parser_context(
+            self,
+            m_batch: int,
+            X_t_pending: torch.Tensor | None,
+            target: list[Target],
+            target_locs: list[int],
+            objective: MCAcquisitionObjective | None = None
+        ):
+
+        # Establish baseline X from training and pending
+        X_train = torch.tensor(self.X_space.encode(self.X_train).values, dtype=TORCH_DTYPE)
+        if X_t_pending is not None:
+            X_baseline = torch.concat([X_train, X_t_pending], axis=0) # type: ignore
+        else:
+            X_baseline = X_train
+
+        # Calculate the performance on baseline X
+        f_all = []
+        for i in target_locs:
+            X_b = pd.DataFrame(X_baseline.numpy(),
+                               columns=[col for col in self.X_t_train.columns
+                                        if col not in self.X_space.X_task])
+            f_i, _ = self.surrogate[i].predict(X_b)
+            f_all.append(f_i)
+        f_t = torch.stack(f_all, axis=1)
+        # Create parser context
+        context: ParserContext = {
+            "f_t": f_t,
+            "X_baseline": X_baseline,
+            "m_batch": m_batch,
+            "n_dim": self.X_space.n_tdim,
+            "target": target,
+            "generator": self.torch_rng,
+            "objective": objective
+        }
+        return context
        
     def _validate_hypers(self,
                          o_dim: int,
@@ -479,23 +523,23 @@ class BayesianOptimizer(Optimizer):
         else:
             # Validate the hypers if provided
             if len(acquisition.items()) != 1:
-                raise ValueError('One dictionary of hyperparameters \
-                                    must be provided for each acquisition function')
+                raise ValueError("One dictionary of hyperparameters "
+                                 "must be provided for each acquisition function")
             aq_str, hps = list(acquisition.items())[0]
             if not isinstance(hps, dict):
                 raise TypeError('Hyperparameters must be provided as a dictionary')
             if not all(key in aq_hp_defaults[aq_str].keys() for key in hps.keys()):
-                raise ValueError('Unknown hyperpameter amongst {hps.keys()} \
-                                    selected for {aq_str}, select from one of \
-                                    {aq_hp_defaults[aq_str].keys()}')
+                raise ValueError(f"Unknown hyperparameter amongst {hps.keys()} "
+                                 f"selected for {aq_str}, select from one of "
+                                 f"{aq_hp_defaults[aq_str].keys()}")
             aq_hps.update(hps)
 
         optim_type = 'single' if o_dim == 1 else 'multi'
 
         # Validate the acquisition name
         if aq_str not in valid_aqs[optim_type]:
-            raise UnsupportedError(f'Each acquisition function must be \
-                                    selected from: {valid_aqs[optim_type]}')
+            raise UnsupportedError(f"Each acquisition function must be "
+                                    f"selected from: {valid_aqs[optim_type]}")
 
         # Fill in empty hypers with defaults, as appropriate
         for key, defaults in aq_hp_defaults[aq_str].items():
@@ -509,129 +553,279 @@ class BayesianOptimizer(Optimizer):
 
         return (aq_str, aq_hps)
 
-    def _parse_aq_kwargs(self,
-                         aq: str,
-                         hps: dict,
-                         m_batch: int,
-                         target_locs: list[int],
-                         model: Model,
-                         X_t_pending: Tensor | None = None,
-                         objective: MCAcquisitionObjective | None = None) -> dict:
-        """
-        Parses the acquisition function keyword arguments based on the selected acquisition
-        function and hyperparameters.
-
-        Args:
-            aq (str): The name of the acquisition function.
-            hps (dict): The hyperparameters for the acquisition function.
-            target_locs (list[int]): Indices of trained targets to use for objective function
-            X_t_pending (Tensor, optional): Suggested points yet to be run
-            objective (GenericMCMultiOutputObjective or GenericMCObjective, optional):
-                The objective used for optimization after calling the target models.
-                Default is ``None``.
-
-        Returns:
-            dict: The parsed acquisition function keyword arguments.
-        """
-        
-        aq_kwargs = {}
-
-        # Establish baseline X from training and pending
-        X_train = torch.tensor(self.X_space.encode(self.X_train).values, dtype=TORCH_DTYPE)
-        if X_t_pending is not None:
-            X_baseline = torch.concat([X_train, X_t_pending], axis=0)
-        else:
-            X_baseline = X_train
-
-        # Calculate the performance on baseline X
-        f_all = []
-        for i in target_locs:
-            X_b = pd.DataFrame(X_baseline.numpy(),
-                               columns=[col for col in self.X_t_train.columns
-                                        if col not in self.X_space.X_task])
-            f_i, _ = self.surrogate[i].predict(X_b)
-            f_all.append(f_i)
-        f_t = torch.stack(f_all, axis=1)
-
-        # If using an objective, want to calculate EI/PI from here
-        o = f_t if not objective else objective(f_t.unsqueeze(0), X_baseline).squeeze(0)
-        if objective:
-            aq_kwargs['objective'] = objective
-        
-        # Improvement aqs based on inflation or deflation of best point
-        if aq in ['EI', 'PI']:
-            o_max = o.max(dim=0).values * (1+hps['inflate'])
-            aq_kwargs.update({'best_f': o_max})
-        
-        # UCB based on: mu + sqrt(beta) * sqrt(variance) = mu + sqrt(beta) * sd
-        if aq == 'UCB':
-            aq_kwargs['beta'] = hps['beta']
-
-        # Noisy aqs require X_train reference
-        if aq in ['NEI', 'NEHVI', 'NParEGO']:
-            aq_kwargs['X_baseline'] = X_baseline
-            if any(isinstance(m, EnsembleModel) for m in model.models):
-                aq_kwargs['cache_root'] = False
-
-        # Hypervolume requires reference point
-        if aq in ['EHVI', 'NEHVI']:
-
-            # The reference point must be in the objective space, by default
-            # use the minimum point - 10% of the range
-            ref_point = hps['ref_point']
-            if ref_point is None:
-                max = o.max(dim=0).values
-                min = o.min(dim=0).values
-                ref_point = min - 0.1 * (max - min)
-            else:
-                ref_point = torch.tensor(ref_point)
-
-            aq_kwargs['ref_point'] = ref_point
-            
-        if aq in ['NParEGO', 'NEHVI']:
-            aq_kwargs['prune_baseline'] = True
-            
-        if aq == 'EHVI':
-            aq_kwargs['partitioning'] = NondominatedPartitioning(aq_kwargs['ref_point'], Y=o)
-
-        if aq == 'NIPV':
-            X_bounds = torch.tensor([[0.0, 1.0]]*self.X_space.n_tdim, dtype=TORCH_DTYPE).T
-            qmc_samples = draw_sobol_samples(bounds=X_bounds, n=128, q=m_batch)
-            aq_kwargs['mc_points'] = qmc_samples.squeeze(-2)
-            aq_kwargs['sampler'] = None
-            if objective:
-                raise UnsupportedError('NIPV does not support objectives')
-
-        if aq == 'NParEGO':
-            w = hps['scalarization_weights']
-            if isinstance(w, list):
-                w = torch.tensor(w)
-                w = w/torch.sum(torch.abs(w))
-            aq_kwargs['scalarization_weights'] = w
-
-        if aq == 'SF':
-            aq_kwargs['X_baseline'] = X_baseline
-
+    def _parse_aq_kwargs(
+            self,
+            aq_name: str,
+            hps: dict[str, Any],
+            model: ModelList | ModelListGP,
+            sampler: ListSampler | SobolQMCNormalSampler | None,
+            X_t_pending: torch.Tensor | None,
+            objective: MCAcquisitionObjective | None,
+            o_dim: int,
+            target: list[Target],
+            target_locs: list[int],
+            m_batch: int,
+            aq_kwargs: dict[str, Any] = {}
+            ):
+        """A wrapper function to validate and parse acquisition function hyperparameters."""
+        # Use aq_kwargs so that extra unnecessary ones in hps get removed for certain aq funcs
+        aq_kwargs.update({'model': model, 'sampler': sampler, 'X_pending': X_t_pending, "objective": objective})
+        # Extract acq function names and custom hyperparameters from the 'acquisition' list in config
+        aq_kwargs, aq_hps = registry.validate_hyperparameters(self.task, o_dim, aq_name, hps, aq_kwargs)
+        context = self._build_parser_context(m_batch, X_t_pending, target, target_locs, objective)
+        aq_kwargs = registry.parse_hyperparameters(aq_name, aq_kwargs, aq_hps, context)
         return aq_kwargs
+
+    def _setup_model_and_objective(
+            self,
+            target: Target | list[Target] | None,
+            objective: MCAcquisitionObjective | None
+        ) -> tuple[ModelList | ModelListGP, int, list[int], list[Target]]:
+        """
+        Set up the model list and validate objective dimensions.
+        
+        Args:
+            target: Target or list of Target objects
+            objective: MCAcquisitionObjective or None
+        
+        Returns:
+            tuple: (model, o_dim, target_locs, target)
+        
+        Raises:
+            IncompatibleObjectiveError: If the objective does not successfully execute on a sample.
+        """
+        target = self._validate_target(target)
+        target_locs = [self.y_names.index(t.name) for t in target]
+        
+        model_list = [one_surrogate.torch_model for i, one_surrogate in enumerate(self.surrogate) 
+                      if i in target_locs]
+        if all(isinstance(m, GPyTorchModel) for m in model_list):
+            model = ModelListGP(*model_list)
+        else:
+            model = ModelList(*model_list)
+        
+        # Determine output dimensions
+        if objective:
+            try:
+                X_sample = self.X_train.iloc[0, :].to_frame().T
+                eval_suggest = self.evaluate(X_sample, target=target, objective=objective)
+                o_dim = len([col for col in eval_suggest.columns if 'Objective' in col])
+            except Exception:
+                raise IncompatibleObjectiveError('Objective(s) did not successfully execute on sample')
+        else:
+            o_dim = len(target_locs)
+        
+        return model, o_dim, target_locs, target
+
+    def _setup_constraints(
+            self,
+            eq_constraints: Linear_Constraint | list[Linear_Constraint] | None,
+            ineq_constraints: Linear_Constraint | list[Linear_Constraint] | None,
+            nleq_constraints: Nonlinear_Constraint | list[Nonlinear_Constraint] | None
+        ) -> tuple[list[Linear_Constraint], list[Linear_Constraint], list[Nonlinear_Constraint]]:
+        """
+        Consolidate and validate all constraints.
+        
+        Args:
+            eq_constraints: Equality constraints (single or list)
+            ineq_constraints: Inequality constraints (single or list)
+            nleq_constraints: Nonlinear constraints (single or list)
+        
+        Returns:
+            tuple: (eq_constraints, ineq_constraints, nleq_constraints) as lists
+        """
+        # Coerce to lists
+        if not eq_constraints:
+            eq_constraints = []
+        if not ineq_constraints:
+            ineq_constraints = []
+        if not nleq_constraints:
+            nleq_constraints = []
+        
+        if not isinstance(eq_constraints, list):
+            eq_constraints = [eq_constraints]
+        if not isinstance(ineq_constraints, list):
+            ineq_constraints = [ineq_constraints]
+        if not isinstance(nleq_constraints, list):
+            nleq_constraints = [nleq_constraints]
+        
+        # Append X_space constraints
+        if getattr(self.X_space, 'linear_constraints', []):
+            for c in self.X_space.linear_constraints:
+                if c.equality:
+                    eq_constraints.append(c)
+                else:
+                    ineq_constraints.append(c)
+        if getattr(self.X_space, 'nonlinear_constraints', []):
+            nleq_constraints += self.X_space.nonlinear_constraints
+        
+        return eq_constraints, ineq_constraints, nleq_constraints
+
+    def _optimize_single_acquisition(
+        self,
+        aq_i: str | dict[str, Any],
+        model: ModelList | ModelListGP,
+        sampler: ListSampler | SobolQMCNormalSampler,
+        X_t_pending: Tensor | None,
+        objective: MCAcquisitionObjective | None,
+        o_dim: int,
+        target: list[Target],
+        target_locs: list[int],
+        m_batch: int,
+        manual_seed: int | None,
+        out_constraints: Output_Constraint | list[Output_Constraint] | None,
+        eq_constraints: list[Linear_Constraint],
+        ineq_constraints: list[Linear_Constraint],
+        nleq_constraints: list[Nonlinear_Constraint],
+        fixed_var: dict[str, float | str] | None,
+        optim_sequential: bool,
+        optim_samples: int,
+        optim_restarts: int,
+        optim_options: dict | None,
+    ) -> tuple[Tensor, pd.DataFrame, pd.DataFrame]:
+        """
+        Optimize a single acquisition function with given constraints.
+        
+        Args:
+            aq_i: Acquisition function specification (string or dict)
+            model: Surrogate model
+            sampler: MC sampler
+            X_t_pending: Pending experiments (torch tensor)
+            objective: Objective function
+            o_dim: Output dimension
+            target: Target or list of targets
+            target_locs: Target locations in y_names
+            m_batch: Batch size
+            out_constraints: Output constraints
+            eq_constraints: Equality constraints
+            ineq_constraints: Inequality constraints
+            nleq_constraints: Nonlinear constraints
+            fixed_var: Fixed variables dict
+            optim_sequential: Whether to optimize sequentially
+            optim_samples: Number of optimization samples
+            optim_restarts: Number of optimization restarts
+            optim_options: Additional optimization options
+        
+        Returns:
+            tuple: (candidates_tensor, candidates_df, eval_df)
+        
+        Raises:
+            UnsupportedError: If acquisition function doesn't support constraints or
+                             if nonlinear constraints are used with discrete features
+        """
+        aq_str, aq_hps = self._normalize_aq_input(aq_i)
+        
+        # Validation for constraints
+        aq_kwargs = {}
+        if aq_str in ['UCB', 'Mean', 'TS', 'SF', 'SR', 'NIPV']:
+            if out_constraints is not None:
+                raise UnsupportedError('Provided acquisition function does not support output constraints')
+        else:
+            if out_constraints and not isinstance(out_constraints, list):
+                out_constraints = [out_constraints]
+            aq_kwargs['constraints'] = [c.forward(scale=objective is None)
+                                        for c in out_constraints] if out_constraints else None
+        
+        aq_kwargs = self._parse_aq_kwargs(aq_str, aq_hps, model, sampler, X_t_pending, 
+                                         objective, o_dim, target, target_locs, m_batch, aq_kwargs)
+        
+        # Cache parsed acquisition arguments
+        self.aq_args[aq_str] = aq_kwargs
+        
+        # Compute fixed features
+        fixed_features_list = self._fixed_features(fixed_var)
+        if len(fixed_features_list) > 25:
+            warnings.warn(f'The combinations of discrete features is large at {len(fixed_features_list)}.'
+                          + ' Optimization will proceed very slowly due to the combinatorial explosion.'
+                          + ' Recommend reducing the number of discrete parameters used.', OptimizerWarning)
+        
+        # Setup optimization kwargs
+        X_bounds = torch.tensor(self.X_space.search_space.values, dtype=TORCH_DTYPE)
+        optim_kwargs: dict[str, Any] = {
+            "equality_constraints": [c() for c in eq_constraints] if eq_constraints else None,
+            "inequality_constraints": [c() for c in ineq_constraints] if ineq_constraints else None,
+            "nonlinear_inequality_constraints": [c() for c in nleq_constraints] if nleq_constraints else None,
+        }
+        
+        # Handle nonlinear constraints
+        if nleq_constraints:
+            X_ic = torch.ones((optim_samples, 1 if fixed_features_list else m_batch, 
+                              self.X_space.n_tdim))*torch.rand(1, generator=self.torch_rng)
+            optim_kwargs['batch_initial_conditions'] = X_ic
+            if fixed_features_list:
+                raise UnsupportedError('Nonlinear constraints are not supported with discrete features.')
+        
+        # Hypervolume aqs special handling
+        if aq_str in ['NEHVI', 'EHVI']:
+            if optim_sequential and X_t_pending is not None:
+                warnings.warn('Hypervolume aqs with X_pending require joint optimization. '
+                             'Setting optim_sequential to False', UserWarning)
+                optim_sequential = False
+        
+        # Optimize
+        aq_func = registry.instantiate_acquisition(aq_str, **aq_kwargs).to(TORCH_DTYPE)
+        
+        if aq_str == 'RS':
+            candidates = aq_func()
+        else:
+            def optimize_acqf_wrapper(fixed_features_list):
+                if fixed_features_list:
+                    optim_func = optimize_acqf_mixed
+                    optim_kwargs["fixed_features_list"] = fixed_features_list
+                else:
+                    optim_func = optimize_acqf
+                    optim_kwargs["sequential"] = optim_sequential
+                
+                candidates, acq_values = optim_func(
+                    acq_function=aq_func,
+                    bounds=X_bounds,
+                    q=m_batch,
+                    num_restarts=optim_restarts,
+                    raw_samples=optim_samples,
+                    options=optim_options,
+                    **optim_kwargs,
+                )
+                return candidates, acq_values
+            
+            # Apply RNG seeding for suggest operation
+            wrapped_func =  self._rng_wrapper(optimize_acqf_wrapper, manual_seed)  # type: ignore
+            candidates, _ = wrapped_func(fixed_features_list)
+        
+        if self.verbose >= 2:
+            print(f'Optimized {aq_str} acquisition function successfully')
+        
+        # Decode candidates
+        candidates_df = self.X_space.decode(
+            pd.DataFrame(candidates.detach().cpu().numpy(),
+                        columns=[col for col in self.X_t_train.columns 
+                                if col not in self.X_space.X_task]))
+        
+        # Evaluate
+        eval_df = self.evaluate(candidates_df, X_t_pending,
+                               target=target, acquisition=aq_i, 
+                               objective=objective, eval_aq=True)
+        
+        return candidates, candidates_df, eval_df
 
     def suggest(self,
                 m_batch: int = 1,
                 target: Target | list[Target] | None = None,
-                acquisition: list[str] | list[dict] = None,
+                acquisition: list[str] | list[dict] | None = None,
                 optim_sequential: bool = True,
                 optim_samples: int = 512,
                 optim_restarts: int = 10,
                 optim_options: dict | None = None,
+                manual_seed: int | None = None,
                 objective: MCAcquisitionObjective | None = None,
                 out_constraints: Output_Constraint | list[Output_Constraint] | None = None,
                 eq_constraints: Linear_Constraint | list[Linear_Constraint] | None = None,
                 ineq_constraints: Linear_Constraint | list[Linear_Constraint] | None = None,
                 nleq_constraints: Nonlinear_Constraint | list[Nonlinear_Constraint] | None = None,
                 task_index: int = 0,
-                fixed_var: dict[str: float | str] | None = None,
+                fixed_var: dict[str, float | str] | None = None,
                 X_pending: pd.DataFrame | None = None,
                 eval_pending: pd.DataFrame | None = None,
-                manual_seed: int | None = None) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+                ) -> tuple[pd.DataFrame, pd.DataFrame]:
         """
         Suggest future experiments based on a maximization of some acquisition
         function calculated from the expectation of a surrogate model.
@@ -696,8 +890,7 @@ class BayesianOptimizer(Optimizer):
                 X_suggest (pd.DataFrame): Experiment matrix of real input variables,
                     selected by optimizer.
                 eval_suggest (pd.DataFrame): Mean results (response, prediction interval, f(response), obj
-                    function for
-                    each suggested experiment.
+                    function for each suggested experiment.
         
         Raises:
             UnfitError: If the surrogate model has not been fit before suggesting new experiments.
@@ -705,79 +898,39 @@ class BayesianOptimizer(Optimizer):
             IncorrectObjectiveError: If the objective does not successfully execute on a sample.
             TypeError: If the acquisition is not a list of strings or dictionaries.
             UnsupportedError: If the provided acquisition function does not support output constraints.
-
         """
-
+        
         if not self.is_fit:
             raise UnfitError('Surrogate model must be fit before suggesting new experiments')
-            
+        
         if self.verbose >= 2:
             print(f'Optimizing {m_batch} experiments [...]')
         
-        # Use indexing to handle if suggestions are made for a subset of fit targets/surrogates
-        target = self._validate_target(target)
-        target_locs = [self.y_names.index(t.name) for t in target]
-        
-        # Select the model(s) to use for optimization
-        model_list = [one_surrogate.torch_model for i, one_surrogate in enumerate(self.surrogate) if i in target_locs]
-        if all(isinstance(m, GPyTorchModel) for m in model_list):
-            model = ModelListGP(*model_list)
-        else:
-            model = ModelList(*model_list)
-
-        # Make sure that model/objective outputs match the input requirements for aqs
-        # In order to determine the number of outputs, considering objectives,
-        # just call the objective on a random sample, and check the output dims
-        if objective:
-            try:
-                X_sample = self.X_train.iloc[0, :].to_frame().T
-                eval_suggest = self.evaluate(X_sample, target=target, objective=objective)
-                o_dim = len([col for col in eval_suggest.columns if 'Objective' in col])
-            except Exception:
-                raise IncompatibleObjectiveError('Objective(s) did not successfully execute on sample')
-        else:
-            o_dim = len(target_locs)
-
+        # Setup model and objective
+        model, o_dim, target_locs, target = self._setup_model_and_objective(target, objective)
         optim_type = 'single' if o_dim == 1 else 'multi'
-
-        # Default if no aq method is provided
+        
+        # Default acquisition
         if not acquisition:
-            acquisition = [aq_defaults[optim_type]]
-
-        # Type check for acquisition
+            acquisition = [aq_defaults[self.task.value][optim_type]]
+        
+        # Type check
         if not isinstance(acquisition, list):
             raise TypeError('acquisition must be a list of strings or dictionaries')
         if not all(isinstance(item, (str, dict)) for item in acquisition):
             raise TypeError('Each item in acquisition list must be either a string or a dictionary')
         
-        # Compute static variable inputs
-        fixed_features_list = self._fixed_features(fixed_var)
-        if len(fixed_features_list) > 25:
-            warnings.warn(f'The combinations of discrete features is large at {len(fixed_features_list)}.'
-                          + ' Optimization will proceed very slowly due to the combinatorial explosion.'
-                          + ' Recommend reducing the number of discrete parameters used.', OptimizerWarning)
+        # Setup constraints
+        eq_constraints, ineq_constraints, nleq_constraints = self._setup_constraints(
+            eq_constraints, ineq_constraints, nleq_constraints)
         
-        # Set up the sampler, for MC-based optimization of acquisition functions
-        if not isinstance(model, ModelListGP):
-            samplers = []
-            for m in model.models:
-                if isinstance(m, EnsembleModel):
-                    sampler_i = IndexSampler(sample_shape=torch.Size([optim_samples]), seed=self.seed)
-                else:
-                    sampler_i = SobolQMCNormalSampler(sample_shape=torch.Size([optim_samples]), seed=self.seed)
-                samplers.append(sampler_i)
-            sampler = ListSampler(*samplers)
-        else:
-            sampler = SobolQMCNormalSampler(sample_shape=torch.Size([optim_samples]), seed=self.seed)
-
-        # Calculate search bounds for optimization
-        X_bounds = torch.tensor(self.X_space.search_space.values, dtype=TORCH_DTYPE)
+        # Setup sampler
+        sampler = self._setup_sampler(model, optim_samples, self.seed)
         
-        # Set up master lists to hold the candidates from multi-acquisition results
+        # Handle pending experiments
         candidates_all = []
         eval_suggest = pd.DataFrame()
-
-        # Incorporate previously suggested X values, if provided
+        
         if X_pending is not None:
             m_pending = X_pending.shape[0]
             candidates_pending = torch.tensor(self.X_space.encode(X_pending).values)
@@ -789,144 +942,56 @@ class BayesianOptimizer(Optimizer):
                 eval_suggest = eval_pending
         else:
             X_t_pending = None
-
-        #  Select the task to optimize for a multi-task model
+        
+        # Handle task index
+        task_name = None
+        task_value = None
         if self.X_space.X_task:
             if objective is not None:
-                objective = Objective_Sequence([Index_Objective(task_index), objective])
+                objective = Objective_Sequence([Index_Objective(task_index), objective])  # type: ignore
             task_param = next(x for x in self.X_space if isinstance(x, Task))
             task_name = task_param.name
-            task_value = task_param.encode([task_param.categories[task_index]])
-
-        # Proceed with the optimization over each set of acquisition/hypers
+            task_value = task_param.encode(np.array([task_param.categories[task_index]]))
+        
+        # Reset parsed acquisition arguments
+        self.aq_args = {}
+        
+        # OPTIMIZATION LOOP
         for aq_i in acquisition:
-            # Extract acq function names and custom hyperparameters from the 'acquisition' list in config
-            aq_str, aq_hps = self._validate_hypers(o_dim, aq_i)
-
-            # Use aq_kwargs so that extra unnecessary ones in hps get removed for certain aq funcs
-            aq_kwargs = {'model': model, 'sampler': sampler, 'X_pending': X_t_pending}
+            candidates, candidates_df, eval_df = self._optimize_single_acquisition(
+                aq_i=aq_i,
+                model=model,
+                sampler=sampler,
+                X_t_pending=X_t_pending,
+                objective=objective,
+                o_dim=o_dim,
+                target=target,
+                target_locs=target_locs,
+                m_batch=m_batch,
+                manual_seed=manual_seed,
+                out_constraints=out_constraints,
+                eq_constraints=eq_constraints,
+                ineq_constraints=ineq_constraints,
+                nleq_constraints=nleq_constraints,
+                fixed_var=fixed_var,
+                optim_sequential=optim_sequential,
+                optim_samples=optim_samples,
+                optim_restarts=optim_restarts,
+                optim_options=optim_options,
+            )
             
-            aq_kwargs.update(self._parse_aq_kwargs(aq_str, aq_hps, m_batch,
-                                                   target_locs, model,
-                                                   X_t_pending, objective))
-
-            # Raise errors related to certain constraints
-            if aq_str in ['UCB', 'Mean', 'TS', 'SF', 'SR', 'NIPV']:
-                if out_constraints is not None:
-                    raise UnsupportedError('Provided aquisition function does not support output constraints')
-            else:
-                if out_constraints and not isinstance(out_constraints, list):
-                    out_constraints = [out_constraints]
-                aq_kwargs['constraints'] = [c.forward(scale=objective is None)
-                                            for c in out_constraints] if out_constraints else None
-
-            # If NoneType, coerce to list
-            if not eq_constraints:
-                eq_constraints = []
-            if not ineq_constraints:
-                ineq_constraints = []
-            if not nleq_constraints:
-                nleq_constraints = []
-
-            # Coerce input constraints to lists
-            if not isinstance(eq_constraints, list):
-                eq_constraints = [eq_constraints]
-            if not isinstance(ineq_constraints, list):
-                ineq_constraints = [ineq_constraints]
-            if not isinstance(nleq_constraints, list):
-                nleq_constraints = [nleq_constraints]
-
-            # Append X_space constraints
-            if getattr(self.X_space, 'linear_constraints', []):
-                for c in self.X_space.linear_constraints:
-                    if c.equality:
-                        eq_constraints.append(c)
-                    else:
-                        ineq_constraints.append(c)
-            if getattr(self.X_space, 'nonlinear_constraints', []):
-                nleq_constraints += self.X_space.nonlinear_constraints
-
-            # Input constraints are used by optim_acqf and friends
-            optim_kwargs: dict[str, Any] = {
-                "equality_constraints": [c() for c in eq_constraints] if eq_constraints else None,
-                "inequality_constraints": [c() for c in ineq_constraints] if ineq_constraints else None,
-                "nonlinear_inequality_constraints": [c() for c in nleq_constraints] if nleq_constraints else None,
-            }
-            
-            # optim_options = {}  # Can optionally specify batch_limit or max_iter
-            
-            # If nonlinear constraints are used, BoTorch doesn't provide an ic_generator
-            # Must provide manual samples = just use random initialization
-            if nleq_constraints:
-                X_ic = torch.ones((optim_samples, 1 if fixed_features_list else m_batch, self.X_space.n_tdim))*torch.rand(1, generator=self.torch_rng)
-                optim_kwargs['batch_initial_conditions'] = X_ic
-                if fixed_features_list:
-                    raise UnsupportedError('Nonlinear constraints are not supported with discrete features.')
-            
-            # Hypervolume aqs fail with X_t_pending when optim_sequential=True
-            if aq_str in ['NEHVI', 'EHVI']:
-                if optim_sequential and X_t_pending is not None:
-                    warnings.warn('Hypervolume aqs with X_pending require joint optimization. \
-                                   Setting optim_sequential to False', UserWarning)
-                    optim_sequential = False
-
-            def optimize_acqf_wrapper(fixed_features_list):
-                if fixed_features_list:
-                    # If there are any discrete values, we must used the mixed integer optimization
-                    optim_func = optimize_acqf_mixed
-                    optim_kwargs["fixed_features_list"] = fixed_features_list
-                else:
-                    optim_func = optimize_acqf
-                    optim_kwargs["sequential"] = optim_sequential
-
-                candidates, _ = optim_func(
-                    acq_function=aq_func,
-                    bounds=X_bounds,
-                    q=m_batch,
-                    num_restarts=optim_restarts,
-                    raw_samples=optim_samples,
-                    options=optim_options,
-                    **optim_kwargs,
-                )
-                return candidates, _
-
-            # If it's random search, no need to do optimization; Otherwise, initialize the aq function and optimize
-            if aq_str == 'RS':
-                candidates = torch.rand((m_batch, self.X_space.n_tdim), generator=self.torch_rng, dtype=TORCH_DTYPE)
-            else:
-                aq_func = aq_class_dict[aq_str](**aq_kwargs).to(TORCH_DTYPE)
-
-                # Wrap with RNG control
-                wrapped_func = self._rng_wrapper(optimize_acqf_wrapper, manual_seed)
-                candidates, _ = wrapped_func(fixed_features_list)
-
-            if self.verbose >= 2:
-                print(f'Optimized {aq_str} acquisition function successfully')
-            
-            candidates_i = self.X_space.decode(
-                pd.DataFrame(candidates.detach().cpu().numpy(),
-                             columns=[col for col in self.X_t_train.columns if col not in self.X_space.X_task]))
-            
-            if X_t_pending is not None:
-                X_t_pending_i = X_t_pending
-            else:
-                X_t_pending_i = None
-            
-            eval_i = self.evaluate(candidates_i, X_t_pending_i,
-                                   target=target, acquisition=aq_i, objective=objective, eval_aq=True)
-            eval_suggest = pd.concat([eval_suggest, eval_i], axis=0).reset_index(drop=True)
-
+            eval_suggest = pd.concat([eval_suggest, eval_df], axis=0).reset_index(drop=True)
             candidates_all.append(candidates)
             X_t_pending = torch.concat(candidates_all)
-                       
-        candidates_all = pd.DataFrame(X_t_pending.detach().cpu().numpy(),
+        
+        # Finalize results
+        candidates_all = pd.DataFrame(torch.concat(candidates_all).detach().cpu().numpy(),
                                       columns=[col for col in self.X_t_train.columns
-                                               if col not in self.X_space.X_task])
-    
+                                              if col not in self.X_space.X_task])
+        
         if self.X_space.X_task:
             candidates_all[task_name] = task_value
         
-        # Arrange suggested experiments into a single dataframe, and compute predictions
         X_suggest = self.X_space.decode(candidates_all)
         
         return X_suggest, eval_suggest
@@ -935,7 +1000,7 @@ class BayesianOptimizer(Optimizer):
                  X_suggest: pd.DataFrame,
                  X_t_pending: Tensor | None = None,
                  target: Target | list[Target] | None = None,
-                 acquisition: str | dict = None,
+                 acquisition: str | dict | None = None,
                  objective: MCAcquisitionObjective | None = None,
                  eval_aq: bool = False) -> pd.DataFrame:
         """
@@ -967,56 +1032,31 @@ class BayesianOptimizer(Optimizer):
         X_t = torch.tensor(self.X_space.encode(X_suggest).values, dtype=TORCH_DTYPE)
         X_t_train = torch.tensor(self.X_space.encode(self.X_train).values, dtype=TORCH_DTYPE)
 
-        # Evaluate f_predict on new and pending points
-        f_all = []
-        f_train_all = []
-        f_pending_all = []
-        for loc in target_locs:
-            # Predict: new suggestions
-            t_model = self.surrogate[loc]
-            mu_i, _ = t_model.predict(self.X_space.encode(X_suggest))
-            f_all.append(mu_i.unsqueeze(1))
-            eval_suggest[f'f({self.target[loc].name})'] = mu_i
-
-            # Training data on select targets
-            mu_i_train, _ = t_model.predict(self.X_space.encode(self.X_train))
-            f_train_all.append(mu_i_train.unsqueeze(1))
-
-            # Pending points if provided
-            if X_t_pending is not None:
-                mu_i_pending, _ = t_model.predict(pd.DataFrame(X_t_pending,
-                                                               columns=[col for col in self.X_t_train.columns
-                                                                        if col not in self.X_space.X_task]))
-                f_pending_all.append(mu_i_pending.unsqueeze(1))
-
-        f_t = torch.concat(f_all, dim=1)
-        f_t_train = torch.concat(f_train_all, dim=1)
+        # Compute f_tensors for new, training, and pending points
+        f_t = self._compute_f_tensors(X_suggest, target_locs)
+        f_t_train = self._compute_f_tensors(self.X_train, target_locs)
+        
         if X_t_pending is not None:
-            f_t_pending = torch.concat(f_pending_all, dim=1)
+            X_pending_df = pd.DataFrame(X_t_pending.detach().cpu().numpy(),
+                                        columns=[col for col in self.X_t_train.columns
+                                                 if col not in self.X_space.X_task])
+            f_t_pending = self._compute_f_tensors(X_pending_df, target_locs)
+        
+        # Add standardized predictions to eval_suggest
+        for i, loc in enumerate(target_locs):
+            eval_suggest[f'{self.target[loc].name} Standardized'] = f_t[:, i].detach().cpu().numpy()
 
+        # Evaluate objectives
+        o = self._evaluate_objectives(f_t, X_t, objective)
+        o_train = self._evaluate_objectives(f_t_train, X_t_train, objective)
+        if X_t_pending is not None:
+            o_pending = self._evaluate_objectives(f_t_pending, X_t_pending, objective)
+        
+        # Store objective values and determine dimensionality
         if objective:
-            # Convert f_predict to tensor and evaluate objective
-            # Must add sample dimension to f_t
-            o = objective(f_t.unsqueeze(0), X_t).squeeze(0)
-            if o.ndim < 2:
-                o = o.unsqueeze(1)  # Rearrange into m x o
-
-            # Store multiple objectives if applicable
             for o_i in range(o.shape[-1]):
                 eval_suggest[f'Objective {o_i+1}'] = o[:, o_i].detach().cpu().numpy()
-
-            # Also calculate for training and pending data (for total hv and pareto calcs)
-            o_train = objective(f_t_train.unsqueeze(0), X_t_train).squeeze(0)
-            if o_train.ndim < 2:
-                o_train = o_train.unsqueeze(1)
-            if X_t_pending is not None:
-                o_pending = objective(f_t_pending.unsqueeze(0), X_t_pending).squeeze(0)
-                if o_pending.ndim < 2:
-                    o_pending = o_pending.unsqueeze(1)
-
-            # Calculate output dimensionality and evaluate acquisition
             o_dim = o.shape[-1]
-            
         else:
             o_dim = len(target_locs)
 
@@ -1025,50 +1065,36 @@ class BayesianOptimizer(Optimizer):
         if eval_aq:
             # Default if no aq method is provided
             if not acquisition:
-                acquisition = [aq_defaults[optim_type]]
+                acquisition = aq_defaults[self.task.value][optim_type]
 
             if not isinstance(acquisition, (str, dict)):
                 raise TypeError('Acquisition must be either a string or a dictionary')
-            
-            model_list = [one_surrogate.torch_model for i, one_surrogate in enumerate(self.surrogate) if i in target_locs]
-            if all(isinstance(m, GPyTorchModel) for m in model_list):
-                model = ModelListGP(*model_list)
+
+            aq_str, aq_hps = self._normalize_aq_input(acquisition)
+
+            if aq_str not in self.aq_args:
+                model_list = [one_surrogate.torch_model for i, one_surrogate in enumerate(self.surrogate) if i in target_locs]
+                if all(isinstance(m, GPyTorchModel) for m in model_list):
+                    model = ModelListGP(*model_list)
+                else:
+                    model = ModelList(*model_list)
+                aq_kwargs = {'model': model, 'sampler': None, 'X_pending': X_t_pending}
+                aq_kwargs = self._parse_aq_kwargs(aq_str, aq_hps, model, None, X_t_pending, None, o_dim, target, target_locs, 1)     
             else:
-                model = ModelList(*model_list)
+                aq_kwargs = self.aq_args[aq_str]
             
-            # Extract acq function names and custom hyperparameters from the 'acquisition' list in config
-            aq_str, aq_hps = self._validate_hypers(o_dim, acquisition)
-
-            # Use aq_kwargs so that extra unnecessary ones in hps get removed for certain aq funcs
-            aq_kwargs = {'model': model, 'sampler': None, 'X_pending': X_t_pending}
-                       
-            aq_kwargs.update(self._parse_aq_kwargs(aq_str, aq_hps, X_suggest.shape[0],
-                                                   target_locs, model,
-                                                   X_t_pending, objective))
-                
-            # If it's random search, no need to evaluate aq
-            if aq_str == 'RS':
-                a_joint = torch.tensor([float('nan')]).repeat(X_t.shape[0]).unsqueeze(1)
-            else:
-                aq_func = aq_class_dict[aq_str](**aq_kwargs)
-
-                # Evaluate acquisition on individual samples, then jointly
-                a = []
-                for x_i in X_t:
-                    a_i = aq_func(x_i.unsqueeze(0))
-                    a.append(a_i.detach().cpu())
-                a = torch.concat(a).unsqueeze(1)
-                a_joint = aq_func(X_t).repeat(X_t.shape[0]).unsqueeze(1)  # Rearrange into m x 1
-
+            # Evaluate acquisition function
+            a, a_joint = self._evaluate_acquisition(X_t, aq_str, aq_kwargs)
+            
+            if aq_str != 'RS':
                 eval_suggest['aq Value'] = a.numpy()
-                
-            eval_suggest['aq Value (joint)'] = a_joint.detach().cpu().numpy()
+            
+            eval_suggest['aq Value (joint)'] = a_joint.detach().cpu().numpy() if a_joint is not None else float('nan')
             eval_suggest['aq Method'] = [aq_str]*X_t.shape[0]
 
         # For multi-output evaluations, calculate pareto and hv considering objectives
         if o_dim > 1:
             if objective is None:
-                o = f_t
                 o_list = [f_t, f_t_train]
                 if X_t_pending is not None:
                     o_list.append(f_t_pending)
@@ -1088,7 +1114,7 @@ class BayesianOptimizer(Optimizer):
     def maximize(self,
                  optim_samples=1026,
                  optim_restarts=50,
-                 fixed_var: dict[str: float | str] | None = None) -> tuple[pd.DataFrame, pd.DataFrame]:
+                 fixed_var: dict[str, float | str] | None = None) -> tuple[pd.DataFrame, pd.DataFrame]:
         """
         Predicts the conditions which return the maximum response value within the parameter space.
 
@@ -1116,3 +1142,107 @@ class BayesianOptimizer(Optimizer):
             eval_suggest = pd.concat([eval_suggest, eval_suggest_i], axis=0)
         
         return X_suggest, eval_suggest
+
+    def _compute_f_tensors(self, X_df: pd.DataFrame, target_locs: list[int]) -> Tensor:
+        """
+        Compute f (transformed objective) tensors for given X data.
+        
+        Args:
+            X_df (pd.DataFrame): Input data in original space
+            target_locs (list[int]): Indices of targets to compute
+        
+        Returns:
+            torch.Tensor: Concatenated f predictions with shape (n_samples, n_targets)
+        """
+        f_all = []
+        for loc in target_locs:
+            t_model = self.surrogate[loc]
+            mu_i, _ = t_model.predict(self.X_space.encode(X_df))
+            f_all.append(mu_i.unsqueeze(1))
+        
+        return torch.concat(f_all, dim=1)
+
+    def _evaluate_objectives(self, f_tensors: Tensor, X_tensors: Tensor, objective: MCAcquisitionObjective | None) -> Tensor:
+        """
+        Evaluate objective function(s) on f tensors.
+        
+        Args:
+            f_tensors (torch.Tensor): Transformed objective values (n x m)
+            X_tensors (torch.Tensor): Input tensors in encoded space (n x d)
+            objective (MCAcquisitionObjective): Objective function
+        
+        Returns:
+            torch.Tensor: Objective values with shape (n x o_dim)
+        """
+        if objective is None:
+            return f_tensors
+        
+        # Evaluate objective with sample dimension
+        o = objective(f_tensors.unsqueeze(0), X_tensors).squeeze(0)
+        if o.ndim < 2:
+            o = o.unsqueeze(1)  # Reshape to (n x 1) if 1D
+        
+        return o
+
+    def _evaluate_acquisition(self, X_t: Tensor, aq_str: str, aq_kwargs: dict[str, Any]) -> tuple[Tensor, Tensor | None]:
+        """
+        Evaluate acquisition function on candidates.
+        
+        Args:
+            X_t (torch.Tensor): Candidate points in encoded space
+            aq_str (str): Acquisition function name
+            aq_kwargs (dict): Acquisition function arguments
+        
+        Returns:
+            tuple: (individual_values, joint_value) - both are torch Tensors
+                individual_values: Acquisition values for each point individually
+                joint_value: Acquisition value for all points jointly
+        """
+        # Random search has no acquisition value
+        if aq_str == 'RS':
+            return torch.tensor([float('nan')]).repeat(X_t.shape[0]).unsqueeze(1), None
+        
+        aq_func = registry.instantiate_acquisition(aq_str, **aq_kwargs)
+        
+        # Evaluate acquisition on individual samples
+        a = []
+        for x_i in X_t:
+            a_i = aq_func(x_i.unsqueeze(0))
+            a.append(a_i.detach().cpu())
+        a = torch.concat(a).unsqueeze(1)
+        
+        # Evaluate acquisition jointly
+        a_joint = aq_func(X_t).repeat(X_t.shape[0]).unsqueeze(1)
+        
+        return a, a_joint
+
+    @staticmethod
+    def _setup_sampler(model: Model | ModelListGP, optim_samples: int, seed: int | None) -> ListSampler | SobolQMCNormalSampler:
+        if not isinstance(model, ModelListGP):
+            samplers = []
+            for m in model.models:
+                if isinstance(m, EnsembleModel):
+                    sampler_i = IndexSampler(sample_shape=torch.Size([optim_samples]), seed=seed)
+                else:
+                    sampler_i = SobolQMCNormalSampler(sample_shape=torch.Size([optim_samples]), seed=seed)
+                samplers.append(sampler_i)
+            sampler = ListSampler(*samplers)
+        else:
+            sampler = SobolQMCNormalSampler(sample_shape=torch.Size([optim_samples]), seed=seed)
+        return sampler
+
+    @staticmethod
+    def _normalize_aq_input(acquisition: str | dict[str, Any]) -> tuple[str, dict[str, Any]]:
+        # Parse acquisition input
+        if isinstance(acquisition, str):
+            aq_name = acquisition
+            hps = {}
+        elif isinstance(acquisition, dict):
+            if len(acquisition) != 1:
+                raise ValueError("One dictionary of hyperparameters must be provided for each acquisition function")
+            aq_name, hps = next(iter(acquisition.items()))
+            if not isinstance(hps, dict):
+                raise TypeError("Hyperparameters must be provided as a dictionary")
+        else:
+            raise TypeError("Acquisition must be a string or a dictionary")
+        return aq_name, hps

--- a/obsidian/optimizer/bayesian.py
+++ b/obsidian/optimizer/bayesian.py
@@ -28,6 +28,8 @@ import pandas as pd
 import numpy as np
 import warnings
 
+UNIQUE_SEEDS = False
+UNIQUE_SEEDS_SAMPLER = False
 
 class BayesianOptimizer(Optimizer):
     """
@@ -80,6 +82,13 @@ class BayesianOptimizer(Optimizer):
                  verbose: int = 1):
        
         super().__init__(X_space=X_space, seed=seed, verbose=verbose)
+        print("  Optimizer seed", seed)
+
+        if UNIQUE_SEEDS:
+            if seed is not None:
+                self.optimizer_rng = torch.Generator().manual_seed(seed)
+            else:
+                self.optimizer_rng = torch.Generator()
 
         self.surrogate_type = []  # Shorthand name as str (as provided)
         self.surrogate_hps = []  # Hyperparameters
@@ -223,10 +232,15 @@ class BayesianOptimizer(Optimizer):
         self.X_best_f = self.X_train.iloc[self.X_best_f_idx, :].to_frame().T
 
         # Instantiate and fit the model(s)
+        if UNIQUE_SEEDS:
+            model_seed = torch.randint(0, 1_000_000, (1,), generator=self.optimizer_rng).item()
+        else:
+            model_seed = self.seed
+        print("    Model seed", model_seed)
         self.surrogate = []
         for i in range(self.n_response):
             self.surrogate.append(
-                SurrogateBoTorch(model_type=self.surrogate_type[i], seed=self.seed,
+                SurrogateBoTorch(model_type=self.surrogate_type[i], seed=model_seed,
                                  verbose=self.verbose >= 2, hps=self.surrogate_hps[i]))
             
             # Handle response NaN values on a response-by-response basis
@@ -719,18 +733,22 @@ class BayesianOptimizer(Optimizer):
                           + ' Recommend reducing the number of discrete parameters used.', OptimizerWarning)
         
         # Set up the sampler, for MC-based optimization of acquisition functions
+        if UNIQUE_SEEDS_SAMPLER:
+            sampler_seed = torch.randint(0, 1_000_000, (1,), generator=self.optimizer_rng).item()
+        else:
+            sampler_seed = self.seed
         if not isinstance(model, ModelListGP):
             samplers = []
             for m in model.models:
                 if isinstance(m, EnsembleModel):
-                    sampler_i = IndexSampler(sample_shape=torch.Size([optim_samples]), seed=self.seed)
+                    sampler_i = IndexSampler(sample_shape=torch.Size([optim_samples]), seed=sampler_seed)
                 else:
-                    sampler_i = SobolQMCNormalSampler(sample_shape=torch.Size([optim_samples]), seed=self.seed)
+                    sampler_i = SobolQMCNormalSampler(sample_shape=torch.Size([optim_samples]), seed=sampler_seed)
                 samplers.append(sampler_i)
             sampler = ListSampler(*samplers)
         else:
-            sampler = SobolQMCNormalSampler(sample_shape=torch.Size([optim_samples]), seed=self.seed)
-            
+            sampler = SobolQMCNormalSampler(sample_shape=torch.Size([optim_samples]), seed=sampler_seed)
+
         # Calculate search bounds for optimization
         X_bounds = torch.tensor(self.X_space.search_space.values, dtype=TORCH_DTYPE)
         

--- a/obsidian/parameters/param_space.py
+++ b/obsidian/parameters/param_space.py
@@ -28,6 +28,8 @@ from obsidian.constraints import (
 from obsidian.exceptions import UnsupportedError
 from obsidian.utils import tensordict_to_dict
 
+from typing import Sequence
+
 import torch
 import numpy as np
 import pandas as pd
@@ -66,7 +68,7 @@ class ParamSpace(IParamSpace):
 
     """
     def __init__(self,
-                 params: list[Parameter]):
+                 params: Sequence[Parameter]):
         
         # Convert to immutable dtype to presever order
         self.params = tuple(params)

--- a/obsidian/parameters/targets.py
+++ b/obsidian/parameters/targets.py
@@ -17,7 +17,8 @@ class Target():
     def __init__(self,
                  name: str,
                  f_transform: str | None = 'Standard',
-                 aim: str = 'max'):
+                 aim: str = 'max',
+                 tracking_only: bool = False):
 
         self.name = name
         if aim not in ['min', 'max']:
@@ -27,6 +28,7 @@ class Target():
         else:
             self.multiplier = 1
         self.aim = aim
+        self.tracking_only = tracking_only
         
         # Ouput scoring, used for transformation OR to create a cost function of multiple outputs/inputs
         if f_transform is not None:
@@ -109,7 +111,7 @@ class Target():
         obj_dict = {'init_attrs': {}}
 
         # Select some optimizer attributes to save directly
-        init_attrs = ['name', 'aim', 'f_transform']
+        init_attrs = ['name', 'aim', 'f_transform', 'tracking_only']
         for attr in init_attrs:
             obj_dict['init_attrs'][attr] = getattr(self, attr)
 

--- a/obsidian/parameters/targets.py
+++ b/obsidian/parameters/targets.py
@@ -134,7 +134,8 @@ class Target():
         new_target = cls(**obj_dict['init_attrs'])
 
         # If the transformer has been fit before saving, refit it
-        f = torch.Tensor(obj_dict['f_raw'])
-        new_target.transform_f(f, fit=True)
+        if 'f_raw' in obj_dict:
+            f = torch.Tensor(obj_dict['f_raw'])
+            new_target.transform_f(f, fit=True)
 
         return new_target

--- a/obsidian/rng.py
+++ b/obsidian/rng.py
@@ -1,0 +1,160 @@
+import random
+import time
+from contextlib import contextmanager
+from functools import partial
+
+import numpy as np
+import torch
+
+
+class GlobalRNG:
+    """
+    A class to manage global random number generation for reproducibility and statistical integrity.
+    """
+
+    def __init__(self, seed: int | None = None):
+        # if seed is none, get a seed from current time and save it
+        if seed is None:
+            # time.time() * 1e6 gives microseconds level accuracy
+            seed = int(time.time() * 1e6) % (2**32 - 1)
+        self.seed = seed
+        torch.use_deterministic_algorithms(True)
+        self.np_rng = np.random.default_rng(seed)
+        self.torch_rng = torch.Generator().manual_seed(seed)
+        print(
+            f"numpy and torch random number generators initialized with seed {seed}. "
+            "Please reuse this seed to reproduce the results."
+        )
+
+    def tmp_seed_override(self, func):
+        """Decorator that samples a seed from the global RNG and temporarily overrides the global random states (numpy, torch, random) for the duration of the decorated function call."""
+        seed: int = get_new_seed(1, self.torch_rng)  # type: ignore
+
+        def wrapper(*args, **kwargs):
+            with with_tmp_seed(seed):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    def save_state(self) -> dict:
+        """Saves the objective and RNG states to a state dictionary"""
+        obj_dict = {
+            "name": self.__class__.__name__,
+            "seed": self.seed,
+            # numpy bit generator state is nested dictionary with only strings and integers
+            "np_rng": self.np_rng.bit_generator.state,
+            # torch generator state is a tensor so convert it to list for serialization
+            "torch_rng": self.torch_rng.get_state().cpu().tolist(),
+        }
+        return obj_dict
+
+    @classmethod
+    def load_state(cls, obj_dict: dict):
+        """Loads the RNG states from a state dictionary"""
+        instance = cls(seed=obj_dict["seed"])
+        instance.np_rng.bit_generator.state = obj_dict["np_rng"]
+        # must be a ByteTensor
+        instance.torch_rng.set_state(torch.ByteTensor(obj_dict["torch_rng"]))
+        print(
+            "numpy and torch random number generators, and their random states "
+            f"restored with seed {instance.seed}. "
+        )
+        return instance
+
+
+USE_OLD_RNG_CONTROL = False
+
+_GLOBAL_RNG: GlobalRNG | None = None
+
+
+def get_global_rng(seed: int | None = None, verbose: bool = False, reset: bool = False):
+    global _GLOBAL_RNG
+    if _GLOBAL_RNG is None or reset:
+        if reset:
+            print(f"Resetting global RNG with seed {seed}.")
+        # when seed is not provided, a seed will be generated based on the current time
+        _GLOBAL_RNG = GlobalRNG(seed=seed)
+    elif seed and seed != _GLOBAL_RNG.seed:
+        raise ValueError(
+            f"Global RNG has already been initialized with seed {_GLOBAL_RNG.seed}, "
+            f"while a different seed {seed} was provided. "
+            "This is not allowed for statistical integrity considerations. "
+            "To reset all random number generators, please restart the Python session "
+            "or explicitly reinitialize the global RNG through `reset_global_rng`."
+        )
+    else:
+        print(f"Retrieving global RNG initialized with seed {_GLOBAL_RNG.seed}.")
+        if seed and verbose:
+            print(
+                "Global RNG has already been initialized with the same seed "
+                f"{_GLOBAL_RNG.seed}. The current global RNG will be reused. "
+                "If this operation is meant to reset the random state, please reset "
+                "the global RNG explicitly through `reset_global_rng`."
+            )
+    return _GLOBAL_RNG
+
+
+def is_global_rng_initialized() -> bool:
+    """Checks if the global RNG has been initialized."""
+    return _GLOBAL_RNG is not None
+
+
+reset_global_rng = partial(get_global_rng, reset=True)
+
+
+def get_new_seed(num: int, generator: torch.Generator | None = None) -> int | list[int]:
+    """
+    Generates a new random 32-bit integer seed or a list of seeds from a given torch generator.
+
+    Args:
+        num (int): The number of seeds to generate.
+        generator (torch.Generator, optional): The generator to use.
+                                              If None, a new default generator is used.
+
+    Returns:
+        int | list[int]: A new random 32-bit integer seed or a list of seeds.
+    """
+    # The default generator is used if none is provided
+    if generator is None:
+        generator = torch.Generator()
+
+    # Generate a single 32-bit integer seed
+    seed = torch.randint(2**32 - 1, (num,), generator=generator)
+    if num > 1:
+        return seed.tolist()
+    else:
+        return seed.item()  # type: ignore
+
+
+@contextmanager
+def with_tmp_seed(seed: int | None = None):
+    """
+    Context manager to temporarily set and restore global seeds for torch, numpy, and
+    the built-in random module, in case of directly passing a generator to an external
+    method is not possible.
+    """
+    if seed is None:
+        yield
+        return
+
+    # Save original random states
+    original_torch_state = torch.get_rng_state()
+    original_numpy_state = np.random.get_state()
+    original_random_state = random.getstate()
+
+    try:
+        # Set new seeds
+        torch.manual_seed(seed)
+        np.random.seed(seed)
+        random.seed(seed)
+        yield
+    finally:
+        # Restore original random states
+        torch.set_rng_state(original_torch_state)
+        np.random.set_state(original_numpy_state)
+        random.setstate(original_random_state)
+
+
+def dummy_decorator(func):
+    """A dummy decorator for backward compatibility."""
+    return func

--- a/obsidian/rng.py
+++ b/obsidian/rng.py
@@ -1,5 +1,6 @@
 import random
 import time
+import warnings
 from contextlib import contextmanager
 from functools import partial
 
@@ -7,9 +8,10 @@ import numpy as np
 import torch
 
 
-class GlobalRNG:
+class RNGManager:
     """
-    A class to manage global random number generation for reproducibility and statistical integrity.
+    A class to manage random number generation for reproducibility and statistical integrity.
+    Coordinates numpy, torch, and built-in random module states.
     """
 
     def __init__(self, seed: int | None = None):
@@ -26,12 +28,33 @@ class GlobalRNG:
             "Please reuse this seed to reproduce the results."
         )
 
-    def tmp_seed_override(self, func):
-        """Decorator that samples a seed from the global RNG and temporarily overrides the global random states (numpy, torch, random) for the duration of the decorated function call."""
-        seed: int = get_new_seed(1, self.torch_rng)  # type: ignore
-
+    def tmp_seed_override(self, func, manual_seed: int | None = None):
+        """
+        Decorator that temporarily overrides global random states (numpy, torch, random) 
+        for the duration of the decorated function call.
+        
+        Args:
+            func: The function to decorate
+            manual_seed: Optional fixed seed. If provided, the same seed is used for every call.
+                        If None, a new seed is sampled from the RNG for each call.
+        
+        Returns:
+            Wrapped function with temporary seed override
+        """
+        
+        if manual_seed is not None:
+            # Use fixed seed (better numerical stability across multiple calls)
+            get_seed = lambda: manual_seed
+        else:
+            # Sample new seed each call (provides stochastic variation)
+            get_seed = lambda: get_new_seed(1, self.torch_rng)  
+        
         def wrapper(*args, **kwargs):
-            with with_tmp_seed(seed):
+            # Move this inside the wrapper to ensure a new seed is only generated when the function is called
+            # not when the decorator is defined
+            # Note that results from the previous version will not be reproducible
+            seed = get_seed() 
+            with with_tmp_seed(seed): # type: ignore
                 return func(*args, **kwargs)
 
         return wrapper
@@ -55,16 +78,19 @@ class GlobalRNG:
         instance.np_rng.bit_generator.state = obj_dict["np_rng"]
         # must be a ByteTensor
         instance.torch_rng.set_state(torch.ByteTensor(obj_dict["torch_rng"]))
-        print(
-            "numpy and torch random number generators, and their random states "
-            f"restored with seed {instance.seed}. "
-        )
+        print(f"numpy and torch random number generators, and their random states restored with seed {instance.seed}. ")
         return instance
+
+    def spawn_child(self, seed: int | None = None) -> "RNGManager":
+        """Create independent child RNG with derived or explicit seed"""
+        if seed is None:
+            seed = get_new_seed(1, self.torch_rng)  # type: ignore
+        return RNGManager(seed=seed)
 
 
 USE_OLD_RNG_CONTROL = False
 
-_GLOBAL_RNG: GlobalRNG | None = None
+_GLOBAL_RNG: RNGManager | None = None
 
 
 def get_global_rng(seed: int | None = None, verbose: bool = False, reset: bool = False):
@@ -73,14 +99,14 @@ def get_global_rng(seed: int | None = None, verbose: bool = False, reset: bool =
         if reset:
             print(f"Resetting global RNG with seed {seed}.")
         # when seed is not provided, a seed will be generated based on the current time
-        _GLOBAL_RNG = GlobalRNG(seed=seed)
-    elif seed and seed != _GLOBAL_RNG.seed:
-        raise ValueError(
+        _GLOBAL_RNG = RNGManager(seed=seed)
+    elif seed is not None and seed != _GLOBAL_RNG.seed:
+        warnings.warn(
             f"Global RNG has already been initialized with seed {_GLOBAL_RNG.seed}, "
-            f"while a different seed {seed} was provided. "
-            "This is not allowed for statistical integrity considerations. "
-            "To reset all random number generators, please restart the Python session "
-            "or explicitly reinitialize the global RNG through `reset_global_rng`."
+            f"but seed {seed} was requested. Returning existing RNG. "
+            "For independent RNG, create Campaign with explicit seed parameter, "
+            f"or use rng = obsidian.create_rng_manager({seed}).",
+            UserWarning,
         )
     else:
         print(f"Retrieving global RNG initialized with seed {_GLOBAL_RNG.seed}.")
@@ -100,6 +126,35 @@ def is_global_rng_initialized() -> bool:
 
 
 reset_global_rng = partial(get_global_rng, reset=True)
+
+
+def create_rng_manager(seed: int | None = None) -> RNGManager:
+    """
+    Create a new isolated RNG manager instance (not global singleton).
+
+    This is the recommended way to create independent RNGs for multiple campaigns
+    or experiments that should not share random state.
+
+    Args:
+        seed: Explicit seed for the RNG manager, or None to generate from current time
+
+    Returns:
+        New independent RNGManager instance
+    """
+    return RNGManager(seed=seed)
+
+
+def create_torch_rng(seed: int) -> torch.Generator:
+    """
+    Create a torch Generator with given seed.
+    
+    Args:
+        seed (int): The seed for the generator.
+    
+    Returns:
+        torch.Generator: A new generator initialized with the given seed.
+    """
+    return torch.Generator().manual_seed(seed)
 
 
 def get_new_seed(num: int, generator: torch.Generator | None = None) -> int | list[int]:
@@ -155,6 +210,6 @@ def with_tmp_seed(seed: int | None = None):
         random.setstate(original_random_state)
 
 
-def dummy_decorator(func):
+def dummy_decorator(func, manual_seed: int | None = None):
     """A dummy decorator for backward compatibility."""
     return func

--- a/obsidian/surrogates/base.py
+++ b/obsidian/surrogates/base.py
@@ -1,5 +1,6 @@
 """Surrogate model class definition"""
 
+import obsidian
 from obsidian.config import TORCH_DTYPE
 
 from abc import ABC, abstractmethod
@@ -46,7 +47,8 @@ class SurrogateModel(ABC):
 
         # Handle randomization seed, considering all 3 sources (torch, random, numpy)
         self.seed = seed
-        if self.seed is not None:
+        # TODO: this part is only for backward compatibility, we should drop it eventually
+        if self.seed is not None and obsidian.USE_OLD_RNG_CONTROL:
             torch.manual_seed(self.seed)
             torch.use_deterministic_algorithms(True)
             np.random.seed(self.seed)

--- a/obsidian/surrogates/botorch.py
+++ b/obsidian/surrogates/botorch.py
@@ -1,5 +1,6 @@
 """Surrogate models built using BoTorch API and torch_model objects"""
 
+from typing import Callable
 from .base import SurrogateModel
 from .config import model_class_dict
 from .utils import fit_pytorch
@@ -13,7 +14,6 @@ from botorch.optim.fit import fit_gpytorch_mll_torch, fit_gpytorch_mll_scipy
 from botorch.models.gpytorch import GPyTorchModel
 from botorch.models.ensemble import EnsembleModel
 from gpytorch.mlls import ExactMarginalLogLikelihood
-from gpytorch.priors import GammaPrior
 from botorch.optim.utils import sample_all_priors
 
 import torch
@@ -29,7 +29,7 @@ MAX_ATTEMPTS = 5
 # BoTorch default is False
 MULTI_STARTS = False
 # Whether to sample all parameters from prior or not
-RANDOM_INITIAL_PARAMETERS = False 
+SAMPLE_INITIAL_PARAMETERS = False 
 
 class SurrogateBoTorch(SurrogateModel):
     """
@@ -53,6 +53,7 @@ class SurrogateBoTorch(SurrogateModel):
                 to estimate uncertainty.
               
         hps (dict): Optional surrogate function hyperparameters.
+        sample_initial_parameters (bool): Whether to sample initial parameters from the prior. If hyperparameters are not provided, BoTorch will by default initialize the model with some built-in heuristics. To override this behavior, use ``sample_initial_parameters`` to sample all hyperparameters from priors.
         mll (ExactMarginalLogLikelihood): The marginal log likelihood of the model.
         torch_model (torch.nn.Module): The torch model for the surrogate.
         loss (float): The loss of the model.
@@ -62,20 +63,20 @@ class SurrogateBoTorch(SurrogateModel):
                  model_type: str = 'GP',
                  seed: int | None = None,
                  verbose: bool = False,
+                 sample_initial_parameters: bool = SAMPLE_INITIAL_PARAMETERS,
                  hps: dict = {}):
         
         super().__init__(model_type=model_type, seed=seed, verbose=verbose)
         
         # Optional surrogate function hyperparameters
         self.hps = hps
-                
-        return
-    
+        self.sample_initial_parameters = sample_initial_parameters        
+
     def init_model(self,
                    X: pd.DataFrame,
                    y: pd.Series,
                    cat_dims: list[int],
-                   task_feature: int):
+                   task_feature: int | None = None):
         """
         Instantiates the torch model for the surrogate.
         Cannot be called during __init__ normally as X,y are required
@@ -85,6 +86,7 @@ class SurrogateBoTorch(SurrogateModel):
             X (pd.DataFrame): Input parameters for the training data.
             y (pd.Series): Training data responses.
             cat_dims (list): A list of indices for categorical dimensions in the input data.
+            task_feature (int, optional): The index of the task feature in the input data.
 
         Returns:
             None. Updates surrogate attributes, including self.torch_model.
@@ -119,26 +121,36 @@ class SurrogateBoTorch(SurrogateModel):
             self.torch_model = model_class_dict[self.model_type](train_X=X_p, train_Y=y_p, **self.hps).to(TORCH_DTYPE)
         
         # self.torch_model.likelihood.noise_covar.noise_prior = GammaPrior(1.1, 10.0)
-        if RANDOM_INITIAL_PARAMETERS:
+        if self.sample_initial_parameters:
             sample_all_priors(self.torch_model)
 
-        return
 
-    def fit(self,
+    def fit(
+            self,
             X: pd.DataFrame,
             y: pd.Series,
-            cat_dims=None,
-            task_feature=None):
+            cat_dims: list,
+            task_feature: int | None = None,
+            optimizer: Callable | None = None,
+            max_attempts: int = MAX_ATTEMPTS,
+            multi_starts: bool = MULTI_STARTS,
+            **optimizer_kwargs
+        ) -> None:
         """
         Fits the surrogate model to data
 
         Args:
             X (pd.DataFrame): Input parameters for the training data
             y (pd.Series): Training data responses
-            cat_dims (list, optional): A list of indices for categorical dimensions in the input data. Default is ``None``.
+            cat_dims (list): A list of indices for categorical dimensions in the input data.
+            task_feature (int, optional): The index of the task feature in the input data. Default is ``None``.
+            optimizer (callable, optional): The optimizer to use for fitting the model. Default is ``None`` and chosen dynamically based on model type.
+            max_attempts (int, optional): The maximum number of attempts to fit the model. Default is ``MAX_ATTEMPTS=5``.
+            multi_starts (bool, optional): Whether to run all ``max_attempts`` restarts with different initializations and pick the best model. Default is ``MULTI_STARTS=True``.
+            **optimizer_kwargs: Additional keyword arguments to pass to the optimizer.
 
         Returns:
-            None. Updates the surrogate model attributes, including regressed parameters.
+            None. Updates the surrogate model attributes in-place, including regressed parameters.
         """
      
         # Instantiate self.torch_model
@@ -157,14 +169,14 @@ class SurrogateBoTorch(SurrogateModel):
         
         if isinstance(self.torch_model, GPyTorchModel):
             self.loss_fcn = ExactMarginalLogLikelihood(self.torch_model.likelihood, self.torch_model)
-            if self.model_type == 'DKL':
-                optimizer = fit_gpytorch_mll_torch
-            else:
-                optimizer = fit_gpytorch_mll_scipy
+            if optimizer:
+                if self.model_type == 'DKL':
+                    optimizer = fit_gpytorch_mll_torch
+                else:
+                    optimizer = fit_gpytorch_mll_scipy
 
             try:
-                fit_gpytorch_mll(self.loss_fcn, optimizer=optimizer, max_attempts=MAX_ATTEMPTS, pick_best_of_all_attempts=MULTI_STARTS)
-                # fit_gpytorch_mll(self.loss_fcn, optimizer=optimizer)
+                fit_gpytorch_mll(self.loss_fcn, optimizer=optimizer, max_attempts=max_attempts, pick_best_of_all_attempts=multi_starts, **optimizer_kwargs)
             except Exception:
                 try:
                     fit_gpytorch_mll(self.loss_fcn, optimizer=fit_gpytorch_mll_torch)

--- a/obsidian/surrogates/botorch.py
+++ b/obsidian/surrogates/botorch.py
@@ -13,6 +13,8 @@ from botorch.optim.fit import fit_gpytorch_mll_torch, fit_gpytorch_mll_scipy
 from botorch.models.gpytorch import GPyTorchModel
 from botorch.models.ensemble import EnsembleModel
 from gpytorch.mlls import ExactMarginalLogLikelihood
+from gpytorch.priors import GammaPrior
+from botorch.optim.utils import sample_all_priors
 
 import torch
 import torch.nn as nn
@@ -20,6 +22,14 @@ import numpy as np
 import pandas as pd
 import warnings
 
+# Maximum number of attempts to fit the model 
+# BoTorch default is 5
+MAX_ATTEMPTS = 5  
+# Whether to use multiple restarts for optimization
+# BoTorch default is False
+MULTI_STARTS = False
+# Whether to sample all parameters from prior or not
+RANDOM_INITIAL_PARAMETERS = False 
 
 class SurrogateBoTorch(SurrogateModel):
     """
@@ -107,6 +117,10 @@ class SurrogateBoTorch(SurrogateModel):
                     self.torch_model = model_class_dict[self.model_type](train_X=X_p, train_Y=y_p, **self.hps)
         else:
             self.torch_model = model_class_dict[self.model_type](train_X=X_p, train_Y=y_p, **self.hps).to(TORCH_DTYPE)
+        
+        # self.torch_model.likelihood.noise_covar.noise_prior = GammaPrior(1.1, 10.0)
+        if RANDOM_INITIAL_PARAMETERS:
+            sample_all_priors(self.torch_model)
 
         return
 
@@ -149,7 +163,8 @@ class SurrogateBoTorch(SurrogateModel):
                 optimizer = fit_gpytorch_mll_scipy
 
             try:
-                fit_gpytorch_mll(self.loss_fcn, optimizer=optimizer)
+                fit_gpytorch_mll(self.loss_fcn, optimizer=optimizer, max_attempts=MAX_ATTEMPTS, pick_best_of_all_attempts=MULTI_STARTS)
+                # fit_gpytorch_mll(self.loss_fcn, optimizer=optimizer)
             except Exception:
                 try:
                     fit_gpytorch_mll(self.loss_fcn, optimizer=fit_gpytorch_mll_torch)

--- a/obsidian/surrogates/botorch.py
+++ b/obsidian/surrogates/botorch.py
@@ -169,7 +169,7 @@ class SurrogateBoTorch(SurrogateModel):
         
         if isinstance(self.torch_model, GPyTorchModel):
             self.loss_fcn = ExactMarginalLogLikelihood(self.torch_model.likelihood, self.torch_model)
-            if optimizer:
+            if not optimizer:
                 if self.model_type == 'DKL':
                     optimizer = fit_gpytorch_mll_torch
                 else:

--- a/obsidian/surrogates/custom_GP.py
+++ b/obsidian/surrogates/custom_GP.py
@@ -65,7 +65,13 @@ class FlatGP(ExactGP, GPyTorchModel):
 
     def __init__(self, train_X, train_Y, nu=2.5):
 
-        super().__init__(train_X, train_Y.squeeze(-1), GaussianLikelihood())
+        likelihood = GaussianLikelihood()
+        # Add a safeguard to prevent failures from singular kernel matrix at the initialization step
+        # The default value is softplus(0) + GreaterThan(1e-4) = ln(2) + 1e-4 = 0.6932471805599453
+        # This makes the initial raw noise exactly 0, which can cause non-PSD problems
+        # Anything not exactly ln(2) + 1e-4 will mitigate this issue
+        likelihood.noise = torch.Tensor([0.6932])
+        super().__init__(train_X, train_Y.squeeze(-1), likelihood)
         
         n_dims = train_X.shape[-1]
         

--- a/obsidian/tests/conftest.py
+++ b/obsidian/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Shared pytest fixtures for obsidian tests"""
+
+import pytest
+import obsidian
+
+
+@pytest.fixture(params=[False, True], ids=["new_rng", "old_rng"])
+def rng_mode(request):
+    """
+    Fixture to test both RNG control modes.
+
+    Parametrizes tests to run with both:
+    - new_rng: USE_OLD_RNG_CONTROL = False (default, RNGManager-based)
+    - old_rng: USE_OLD_RNG_CONTROL = True (legacy, direct seeding)
+
+    Automatically resets to default after each test.
+    """
+    original = obsidian.USE_OLD_RNG_CONTROL
+    obsidian.USE_OLD_RNG_CONTROL = request.param
+    yield request.param
+    obsidian.USE_OLD_RNG_CONTROL = original

--- a/obsidian/tests/conftest.py
+++ b/obsidian/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Shared pytest fixtures for obsidian tests"""
+
+import pytest
+import torch
+from obsidian.config import TORCH_DTYPE
+
+
+@pytest.fixture(autouse=True)
+def set_default_dtype():
+    torch.set_default_dtype(TORCH_DTYPE)
+    yield

--- a/obsidian/tests/test_campaign.py
+++ b/obsidian/tests/test_campaign.py
@@ -11,9 +11,11 @@ from obsidian.exceptions import IncompatibleObjectiveError, UnfitError
 from obsidian.tests.param_configs import X_sp_cont_ndims, X_sp_default
 from obsidian.tests.utils import DEFAULT_MOO_PATH, DEFAULT_SOO_PATH, equal_state_dicts
 
+from numpy.testing import assert_array_equal
 import pandas as pd
 import pytest
 import json
+import warnings
  
 # Avoid using TkAgg which causes Tcl issues during testing
 import matplotlib
@@ -36,19 +38,19 @@ def test_campaign_basics(X_space, sim_fcn, target, rng_mode):
     X0 = campaign.suggest()
     y0 = simulator.simulate(X0)
     Z0 = pd.concat([X0, y0], axis=1)
-    
+
     # Set an objective, suggest, clear
     campaign.set_objective(Identity_Objective(mo=len(campaign.target) > 1))
     campaign.suggest()
     campaign.clear_objective()
-    
+
     # Add, fit, clear, examine
     campaign.add_data(Z0)
     campaign.fit()
     campaign.clear_data()
     campaign.y
     campaign.__repr__()
-    
+
     # Add with iteration, examine, fit, analyze
     Z0['Iteration'] = 5
     campaign.add_data(Z0)
@@ -62,6 +64,74 @@ def test_campaign_basics(X_space, sim_fcn, target, rng_mode):
     campaign2 = Campaign.load_state(obj_dict)
     obj_dict2 = campaign2.save_state()
     assert equal_state_dicts(obj_dict, obj_dict2), 'Error during serialization'
+
+
+@pytest.mark.parametrize('X_space, sim_fcn, target',
+                         [(X_sp_cont_ndims[2], two_leaves, target_test[0]),
+                          (X_sp_default, shifted_parab, target_test[1])])
+def test_campaign_unfitted_save_load(X_space, sim_fcn, target, rng_mode):
+    """Test that unfitted campaigns can be saved and loaded, then independently fitted"""
+    # Create unfitted campaign
+    campaign1 = Campaign(X_space, target, seed=114514)
+
+    # Save unfitted campaign (will trigger warning from optimizer.load_state)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        obj_dict = campaign1.save_state()
+
+        # Load unfitted campaign
+        campaign2 = Campaign.load_state(obj_dict)
+
+        # Expect warning from loading unfitted optimizer
+        assert any("unfitted" in str(warning.message).lower() for warning in w)
+
+    # Verify both campaigns are unfitted
+    assert not campaign1.optimizer.is_fit
+    assert not campaign2.optimizer.is_fit
+
+    # Generate same data for both campaigns
+    simulator = Simulator(X_space, sim_fcn, eps=0.05, rng=114514)
+    X0 = campaign1.suggest()
+    y0 = simulator.simulate(X0)
+    Z0 = pd.concat([X0, y0], axis=1)
+
+    # Add iteration column
+    Z0['Iteration'] = 1
+
+    # Fit both campaigns independently with same data
+    campaign1.add_data(Z0)
+    campaign1.fit()
+
+    campaign2.add_data(Z0)
+    campaign2.fit()
+
+    # Both should now be fitted
+    assert campaign1.optimizer.is_fit
+    assert campaign2.optimizer.is_fit
+
+    # Verify they produce the same results
+    # Compare response_max
+    rm1 = campaign1.response_max
+    rm2 = campaign2.response_max
+    if isinstance(rm1, pd.Series) and isinstance(rm2, pd.Series):
+        assert_array_equal(rm1.to_numpy(), rm2.to_numpy())
+    elif not isinstance(rm1, pd.Series) and not isinstance(rm2, pd.Series):
+        assert abs(float(rm1) - float(rm2)) < 1e-6
+    else:
+        raise AssertionError("response_max types don't match between campaigns")
+
+    # Compare X_best (use DataFrame comparison to handle categorical variables)
+    pd.testing.assert_frame_equal(campaign1.X_best, campaign2.X_best)
+
+    # Compare predictions at training points
+    y_pred1 = campaign1.optimizer.predict(campaign1.optimizer.X_train)
+    y_pred2 = campaign2.optimizer.predict(campaign2.optimizer.X_train)
+    assert_array_equal(y_pred1.values, y_pred2.values)
+
+    # Verify round-trip serialization works after fitting
+    obj_dict1 = campaign1.save_state()
+    obj_dict2 = campaign2.save_state()
+    assert equal_state_dicts(obj_dict1, obj_dict2), 'Fitted campaigns should have identical states'
     
     
 # Load default

--- a/obsidian/tests/test_campaign.py
+++ b/obsidian/tests/test_campaign.py
@@ -29,10 +29,10 @@ target_test = [
 @pytest.mark.parametrize('X_space, sim_fcn, target',
                          [(X_sp_cont_ndims[2], two_leaves, target_test[0]),
                           (X_sp_default, shifted_parab, target_test[1])])
-def test_campaign_basics(X_space, sim_fcn, target):
+def test_campaign_basics(X_space, sim_fcn, target, rng_mode):
     # Standard usage
-    campaign = Campaign(X_space, target)
-    simulator = Simulator(X_space, sim_fcn, eps=0.05)
+    campaign = Campaign(X_space, target, seed=114514)
+    simulator = Simulator(X_space, sim_fcn, eps=0.05, rng=114514)
     X0 = campaign.suggest()
     y0 = simulator.simulate(X0)
     Z0 = pd.concat([X0, y0], axis=1)
@@ -67,6 +67,9 @@ def test_campaign_basics(X_space, sim_fcn, target):
 # Load default
 with open(DEFAULT_MOO_PATH) as json_file:
     obj_dict = json.load(json_file)
+    # Override seeds for determinism with new RNG control
+    obj_dict['seed'] = 114514
+    obj_dict['optimizer']['opt_attrs']['seed'] = 114514
 campaign = Campaign.load_state(obj_dict)
 X_space = campaign.X_space
 target = campaign.target
@@ -76,6 +79,9 @@ def test_explain():
     # SOO includes discrete variables
     with open(DEFAULT_SOO_PATH) as json_file:
         obj_dict = json.load(json_file)
+        # Override seeds for determinism with new RNG control
+        obj_dict['seed'] = 114514
+        obj_dict['optimizer']['opt_attrs']['seed'] = 114514
     campaign = Campaign.load_state(obj_dict)
     
     # Standard usage

--- a/obsidian/tests/test_campaign.py
+++ b/obsidian/tests/test_campaign.py
@@ -224,6 +224,13 @@ def test_campaign_validation():
 
 
 @pytest.mark.fast
+def test_campaign_warns_all_tracking_only_targets(rng_mode):
+    tracking_only_target = Target(name='Response', f_transform='Standard', aim='max', tracking_only=True)
+    with pytest.warns(UserWarning, match='All targets are tracking-only'):
+        Campaign(X_sp_default, tracking_only_target, seed=114514)
+
+
+@pytest.mark.fast
 def test_explainer_validation():
     
     # Unfit optimizer

--- a/obsidian/tests/test_constraints.py
+++ b/obsidian/tests/test_constraints.py
@@ -16,6 +16,9 @@ import json
 # Load defaults
 with open(DEFAULT_MOO_PATH) as json_file:
     obj_dict = json.load(json_file)
+    # Override seeds for determinism with new RNG control
+    obj_dict['seed'] = 114514
+    obj_dict['optimizer']['opt_attrs']['seed'] = 114514
 campaign = Campaign.load_state(obj_dict)
 
 optimizer = campaign.optimizer

--- a/obsidian/tests/test_objectives.py
+++ b/obsidian/tests/test_objectives.py
@@ -22,9 +22,12 @@ import pandas as pd
 import pytest
 import json
 
-# Load default
+# Load default campaign
 with open(DEFAULT_MOO_PATH) as json_file:
     obj_dict = json.load(json_file)
+    # Override seeds for determinism with new RNG control
+    obj_dict['seed'] = 114514
+    obj_dict['optimizer']['opt_attrs']['seed'] = 114514
 campaign = Campaign.load_state(obj_dict)
 X_space = campaign.X_space
 target = campaign.target
@@ -64,6 +67,8 @@ def test_campaign_objectives(obj):
 
     # Serialize, deserialize, re-serialize
     obj_dict = campaign.save_state()
+    obj_dict['seed'] = 114514
+    obj_dict['optimizer']['opt_attrs']['seed'] = 114514
     campaign2 = Campaign.load_state(obj_dict)
     obj_dict2 = campaign2.save_state()
     assert equal_state_dicts(obj_dict, obj_dict2), 'Error during serialization'

--- a/obsidian/tests/test_optimizer_MOO.py
+++ b/obsidian/tests/test_optimizer_MOO.py
@@ -9,10 +9,12 @@ from obsidian.experiment.benchmark import two_leaves
 from obsidian.tests.utils import equal_state_dicts
 
 from botorch.models.ensemble import EnsembleModel
-      
+
+from numpy.testing import assert_array_equal
 import pandas as pd
 import numpy as np
 import pytest
+import warnings
 
 
 @pytest.fixture()
@@ -134,6 +136,204 @@ def test_optimizer_aqs(aq):
 def test_optimizer_maximize():
     X_suggest, eval_suggest = optimizer.maximize(**test_config)
     df_suggest = pd.concat([X_suggest, eval_suggest], axis=1)
+
+
+@pytest.mark.fast
+def test_save_load_unfitted_optimizer(X_space):
+    """Test that unfitted optimizers can be saved and loaded"""
+    # Create unfitted optimizer
+    opt1 = BayesianOptimizer(X_space, surrogate='GP', seed=42, verbose=0)
+
+    # Save state before fitting
+    state = opt1.save_state()
+
+    # Verify state structure
+    assert 'X_space' in state
+    assert 'surrogate_spec' in state
+    assert 'is_fitted' in state
+    assert state['is_fitted'] == False
+    assert 'target' not in state  # Should not be present for unfitted
+    assert 'model_states' not in state  # Should not be present for unfitted
+
+    # Load the unfitted optimizer
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        opt2 = BayesianOptimizer.load_state(state)
+        # Verify warning was issued
+        assert len(w) == 1
+        assert issubclass(w[0].category, UserWarning)
+        assert "unfitted" in str(w[0].message).lower()
+
+    # Verify properties
+    assert opt2.is_fit == False
+    assert not hasattr(opt2, 'target')
+    assert not hasattr(opt2, 'surrogate')
+    assert opt2.surrogate_type == opt1.surrogate_type
+    assert opt2.surrogate_hps == opt1.surrogate_hps
+    assert opt2.seed == opt1.seed
+
+    # Verify it can still be fitted
+    designer = ExpDesigner(X_space, seed=1)
+    X0 = designer.initialize(m_initial=len(X_space)*2, method='LHS')
+    simulator = Simulator(X_space, two_leaves, eps=0.05, rng=1)
+    y0 = simulator.simulate(X0)
+    Z0 = pd.concat([X0, y0], axis=1)
+    targets = [
+        Target(name='Response 1', f_transform='Standard', aim='max'),
+        Target(name='Response 2', f_transform='Standard', aim='max')
+    ]
+    opt2.fit(Z0, target=targets)
+    assert opt2.is_fit == True
+
+    # Save and load again after fitting
+    state2 = opt2.save_state()
+    assert state2['is_fitted'] == True
+    assert 'target' in state2
+    assert 'model_states' in state2
+
+
+@pytest.mark.fast
+def test_load_legacy_fitted_state(X_space, Z0):
+    """Test that old saved states (without is_fitted flag) still load correctly"""
+    # Create and fit optimizer
+    opt1 = BayesianOptimizer(X_space, surrogate='GP', seed=42, verbose=0)
+    targets = [
+        Target(name='Response 1', f_transform='Standard', aim='max'),
+        Target(name='Response 2', f_transform='Standard', aim='max')
+    ]
+    opt1.fit(Z0, target=targets)
+
+    # Save state
+    state = opt1.save_state()
+
+    # Simulate legacy state by removing is_fitted flag
+    if 'is_fitted' in state:
+        del state['is_fitted']
+
+    # Should still load correctly
+    opt2 = BayesianOptimizer.load_state(state)
+    assert opt2.is_fit == True  # Inferred from presence of model_states
+
+    # Predictions should match
+    y_pred = opt1.predict(opt1.X_train)
+    y_pred_2 = opt2.predict(opt2.X_train)
+    assert_array_equal(y_pred.values, y_pred_2.values)
+
+
+@pytest.mark.fast
+def test_unfitted_to_fitted_cycle(X_space, Z0):
+    """Test complete cycle: create -> save -> load -> fit -> save -> load"""
+    targets = [
+        Target(name='Response 1', f_transform='Standard', aim='max'),
+        Target(name='Response 2', f_transform='Standard', aim='max')
+    ]
+
+    # 1. Create unfitted optimizer
+    opt1 = BayesianOptimizer(X_space, surrogate='GP', seed=42, verbose=0)
+
+    # 2. Save unfitted state
+    state_unfitted = opt1.save_state()
+    assert state_unfitted['is_fitted'] == False
+
+    # 3. Load unfitted state
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        opt2 = BayesianOptimizer.load_state(state_unfitted)
+    assert opt2.is_fit == False
+
+    # 4. Fit the loaded optimizer
+    opt2.fit(Z0, target=targets)
+    assert opt2.is_fit == True
+
+    # 5. Save fitted state
+    state_fitted = opt2.save_state()
+    assert state_fitted['is_fitted'] == True
+
+    # 6. Load fitted state
+    opt3 = BayesianOptimizer.load_state(state_fitted)
+    assert opt3.is_fit == True
+
+    # 7. Verify predictions match
+    y_pred_2 = opt2.predict(opt2.X_train)
+    y_pred_3 = opt3.predict(opt3.X_train)
+    assert_array_equal(y_pred_2.values, y_pred_3.values)
+
+
+@pytest.mark.fast
+def test_unfitted_state_round_trip(X_space):
+    """Test that unfitted optimizer state round-trips correctly"""
+    opt1 = BayesianOptimizer(X_space, surrogate='GP', seed=42, verbose=0)
+
+    # Save and load twice
+    state1 = opt1.save_state()
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        opt2 = BayesianOptimizer.load_state(state1)
+    state2 = opt2.save_state()
+
+    # States should be identical
+    assert equal_state_dicts(state1, state2)
+
+
+@pytest.mark.fast
+def test_unfitted_optimizer_operations(X_space):
+    """Test that unfitted optimizer properly raises errors for operations requiring fit"""
+    from obsidian.exceptions import UnfitError
+
+    opt = BayesianOptimizer(X_space, surrogate='GP', seed=42, verbose=0)
+
+    # Save should work
+    state = opt.save_state()
+    assert state['is_fitted'] == False
+
+    # Create a dummy DataFrame for predictions
+    designer = ExpDesigner(X_space, seed=1)
+    X_test = designer.initialize(m_initial=1, method='LHS')
+
+    # These operations should fail on unfitted optimizer
+    with pytest.raises(UnfitError):
+        opt.predict(X_test)
+
+    with pytest.raises(UnfitError):
+        opt.suggest(m_batch=1)
+
+    with pytest.raises(UnfitError):
+        opt.evaluate(X_test)
+
+
+@pytest.mark.fast
+def test_save_load_warnings(X_space, Z0, capsys):
+    """Test that warnings are issued correctly"""
+    # Test 1: Loading unfitted state issues UserWarning
+    opt_unfitted = BayesianOptimizer(X_space, surrogate='GP', seed=42, verbose=0)
+    state_unfitted = opt_unfitted.save_state()
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        BayesianOptimizer.load_state(state_unfitted)
+        assert len(w) == 1
+        assert issubclass(w[0].category, UserWarning)
+        assert "unfitted" in str(w[0].message).lower()
+
+    # Test 2: Saving unfitted optimizer prints info message (when verbose)
+    opt_verbose = BayesianOptimizer(X_space, surrogate='GP', seed=42, verbose=1)
+    opt_verbose.save_state()
+    captured = capsys.readouterr()
+    assert "unfitted" in captured.out.lower() or "configuration" in captured.out.lower()
+
+    # Test 3: Loading legacy state prints info message
+    targets = [
+        Target(name='Response 1', f_transform='Standard', aim='max'),
+        Target(name='Response 2', f_transform='Standard', aim='max')
+    ]
+    opt_fitted = BayesianOptimizer(X_space, surrogate='GP', seed=42, verbose=0)
+    opt_fitted.fit(Z0, target=targets)
+    state_legacy = opt_fitted.save_state()
+    del state_legacy['is_fitted']  # Make it look like legacy
+
+    BayesianOptimizer.load_state(state_legacy)
+    captured = capsys.readouterr()
+    assert "older version" in captured.out.lower() or "missing" in captured.out.lower()
 
 
 if __name__ == '__main__':

--- a/obsidian/tests/test_optimizer_MOO.py
+++ b/obsidian/tests/test_optimizer_MOO.py
@@ -7,7 +7,6 @@ from obsidian.experiment import ExpDesigner, Simulator
 from obsidian.optimizer import BayesianOptimizer
 from obsidian.experiment.benchmark import two_leaves
 from obsidian.tests.utils import equal_state_dicts
-
 from botorch.models.ensemble import EnsembleModel
 
 from numpy.testing import assert_array_equal
@@ -136,6 +135,87 @@ def test_optimizer_aqs(aq):
 def test_optimizer_maximize():
     X_suggest, eval_suggest = optimizer.maximize(**test_config)
     df_suggest = pd.concat([X_suggest, eval_suggest], axis=1)
+
+
+@pytest.mark.fast
+def test_suggest_ignores_tracking_targets_by_default():
+    optimizer_tracking = BayesianOptimizer(base_X_space, surrogate='GP', seed=0, verbose=0)
+    tracking_targets = [
+        Target(name='Response 1', f_transform='Standard', aim='max'),
+        Target(name='Response 2', f_transform='Standard', aim='max', tracking_only=True),
+    ]
+    optimizer_tracking.fit(Z0_base, target=tracking_targets)
+
+    _, eval_suggest = optimizer_tracking.suggest(m_batch=1, **test_config)
+    assert eval_suggest['aq Method'].iloc[0] == 'NEI'
+
+
+@pytest.mark.fast
+def test_suggest_warns_tracking_only_target_when_explicitly_requested():
+    optimizer_tracking = BayesianOptimizer(base_X_space, surrogate='GP', seed=0, verbose=0)
+    tracking_targets = [
+        Target(name='Response 1', f_transform='Standard', aim='max'),
+        Target(name='Response 2', f_transform='Standard', aim='max', tracking_only=True),
+    ]
+    optimizer_tracking.fit(Z0_base, target=tracking_targets)
+
+    with pytest.warns(UserWarning, match='tracking-only'):
+        _, eval_suggest = optimizer_tracking.suggest(
+            m_batch=1,
+            target=Target(name='Response 2', f_transform='Standard', aim='max', tracking_only=True),
+            **test_config,
+        )
+    assert eval_suggest['aq Method'].iloc[0] == 'NEI'
+
+
+@pytest.mark.fast
+def test_suggest_rejects_unknown_target_when_target_provided():
+    optimizer_tracking = BayesianOptimizer(base_X_space, surrogate='GP', seed=0, verbose=0)
+    tracking_targets = [
+        Target(name='Response 1', f_transform='Standard', aim='max'),
+        Target(name='Response 2', f_transform='Standard', aim='max', tracking_only=True),
+    ]
+    optimizer_tracking.fit(Z0_base, target=tracking_targets)
+
+    with pytest.raises(NameError):
+        optimizer_tracking.suggest(
+            m_batch=1,
+            target=Target(name='Response 3', f_transform='Standard', aim='max'),
+            **test_config,
+        )
+
+
+def test_maximize_includes_tracking_only_without_warning():
+    optimizer_tracking = BayesianOptimizer(base_X_space, surrogate='GP', seed=0, verbose=0)
+    tracking_targets = [
+        Target(name='Response 1', f_transform='Standard', aim='max'),
+        Target(name='Response 2', f_transform='Standard', aim='max', tracking_only=True),
+    ]
+    optimizer_tracking.fit(Z0_base, target=tracking_targets)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        X_all, _ = optimizer_tracking.maximize(**test_config)
+    assert X_all.shape[0] == 2
+    assert not any('tracking-only' in str(w_i.message).lower() for w_i in w)
+
+
+@pytest.mark.fast
+def test_save_load_preserves_tracking_only_targets():
+    optimizer_tracking = BayesianOptimizer(base_X_space, surrogate='GP', seed=0, verbose=0)
+    tracking_targets = [
+        Target(name='Response 1', f_transform='Standard', aim='max'),
+        Target(name='Response 2', f_transform='Standard', aim='max', tracking_only=True),
+    ]
+    optimizer_tracking.fit(Z0_base, target=tracking_targets)
+
+    state = optimizer_tracking.save_state()
+    optimizer_loaded = BayesianOptimizer.load_state(state)
+
+    assert optimizer_loaded.target[1].tracking_only == True
+
+    X_all, _ = optimizer_loaded.maximize(**test_config)
+    assert X_all.shape[0] == 2
 
 
 @pytest.mark.fast

--- a/obsidian/tests/test_optimizer_MOO.py
+++ b/obsidian/tests/test_optimizer_MOO.py
@@ -24,7 +24,7 @@ def X_space():
 def Z0(X_space):
     designer = ExpDesigner(X_space, seed=0)
     X0 = designer.initialize(m_initial=len(X_space)*2, method='LHS')
-    simulator = Simulator(X_space, two_leaves, eps=0.05)
+    simulator = Simulator(X_space, two_leaves, eps=0.05, rng=0)
     y0 = simulator.simulate(X0)
     Z0 = pd.concat([X0, y0], axis=1)
     return Z0
@@ -71,7 +71,7 @@ base_X_space = X_sp_cont_ndims[2]
 optimizer = BayesianOptimizer(base_X_space, surrogate='GP', seed=0, verbose=0)
 designer = ExpDesigner(base_X_space, seed=0)
 X0 = designer.initialize(m_initial=6, method='LHS')
-simulator = Simulator(base_X_space, two_leaves, eps=0.05)
+simulator = Simulator(base_X_space, two_leaves, eps=0.05, rng=0)
 y0 = simulator.simulate(X0)
 Z0_base = pd.concat([X0, y0], axis=1)
 optimizer.fit(Z0_base, target=target)

--- a/obsidian/tests/test_optimizer_SOO.py
+++ b/obsidian/tests/test_optimizer_SOO.py
@@ -25,7 +25,7 @@ def X_space(request):
 def Z0(X_space):
     designer = ExpDesigner(X_space, seed=1)
     X0 = designer.initialize(m_initial=len(X_space)*2, method='LHS')
-    simulator = Simulator(X_space, shifted_parab, eps=0.05)
+    simulator = Simulator(X_space, shifted_parab, eps=0.05, rng=1)
     y0 = simulator.simulate(X0)
     Z0 = pd.concat([X0, y0], axis=1)
     return Z0
@@ -97,7 +97,7 @@ base_X_space = X_sp_default
 optimizer = BayesianOptimizer(base_X_space, surrogate='GP', seed=0, verbose=0)
 designer = ExpDesigner(base_X_space, seed=0)
 X0 = designer.initialize(m_initial=6, method='LHS')
-simulator = Simulator(base_X_space, shifted_parab, eps=0.05)
+simulator = Simulator(base_X_space, shifted_parab, eps=0.05, rng=0)
 y0 = simulator.simulate(X0)
 Z0_base = pd.concat([X0, y0], axis=1)
 optimizer.fit(Z0_base, target=target)

--- a/obsidian/tests/test_optimizer_SOO.py
+++ b/obsidian/tests/test_optimizer_SOO.py
@@ -6,13 +6,15 @@ from obsidian.parameters import Target
 from obsidian.experiment import ExpDesigner, Simulator
 from obsidian.optimizer import BayesianOptimizer
 from obsidian.experiment.benchmark import shifted_parab
-from obsidian.tests.utils import approx_equal, equal_state_dicts
+from obsidian.tests.utils import equal_state_dicts
 
 from botorch.models.ensemble import EnsembleModel
 
+from numpy.testing import assert_allclose
 import pandas as pd
 import numpy as np
 import pytest
+import warnings
 
 
 # Test a variety of preset parameter spaces
@@ -44,7 +46,7 @@ def test_f_transform(X_space, Z0, f_transform):
     y_train = optimizer.y_train
     f_train = target.transform_f(y_train)
     f_train_inv = target.transform_f(f_train, inverse=True)
-    assert approx_equal(y_train.values.flatten(), f_train_inv.values.flatten())
+    assert_allclose(y_train.values.flatten(), f_train_inv.values.flatten())
     
     target = Target(name='Response', f_transform=f_transform, aim='min')
     optimizer.fit(Z0, target=target)
@@ -53,7 +55,7 @@ def test_f_transform(X_space, Z0, f_transform):
     y_train = optimizer.y_train
     f_train = target.transform_f(y_train)
     f_train_inv = target.transform_f(f_train, inverse=True)
-    assert approx_equal(y_train.values.flatten(), f_train_inv.values.flatten())
+    assert_allclose(y_train.values.flatten(), f_train_inv.values.flatten())
 
 
 target = Target(name='Response', f_transform='Standard', aim='max')
@@ -166,6 +168,192 @@ def test_optimizer_aqs(aq):
 def test_optimizer_maximize():
     X_suggest, eval_suggest = optimizer.maximize(**test_config)
     df_suggest = pd.concat([X_suggest, eval_suggest], axis=1)
+
+
+@pytest.mark.fast
+def test_save_load_unfitted_optimizer(X_space):
+    """Test that unfitted optimizers can be saved and loaded"""
+    # Create unfitted optimizer
+    opt1 = BayesianOptimizer(X_space, surrogate='GP', seed=42, verbose=0)
+
+    # Save state before fitting
+    state = opt1.save_state()
+
+    # Verify state structure
+    assert 'X_space' in state
+    assert 'surrogate_spec' in state
+    assert 'is_fitted' in state
+    assert state['is_fitted'] == False
+    assert 'target' not in state  # Should not be present for unfitted
+    assert 'model_states' not in state  # Should not be present for unfitted
+
+    # Load the unfitted optimizer
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        opt2 = BayesianOptimizer.load_state(state)
+        # Verify warning was issued
+        assert len(w) == 1
+        assert issubclass(w[0].category, UserWarning)
+        assert "unfitted" in str(w[0].message).lower()
+
+    # Verify properties
+    assert opt2.is_fit == False
+    assert not hasattr(opt2, 'target')
+    assert not hasattr(opt2, 'surrogate')
+    assert opt2.surrogate_type == opt1.surrogate_type
+    assert opt2.surrogate_hps == opt1.surrogate_hps
+    assert opt2.seed == opt1.seed
+
+    # Verify it can still be fitted
+    designer = ExpDesigner(X_space, seed=1)
+    X0 = designer.initialize(m_initial=len(X_space)*2, method='LHS')
+    simulator = Simulator(X_space, shifted_parab, eps=0.05, rng=1)
+    y0 = simulator.simulate(X0)
+    Z0 = pd.concat([X0, y0], axis=1)
+    target = Target(name='Response', f_transform='Standard', aim='max')
+    opt2.fit(Z0, target=target)
+    assert opt2.is_fit == True
+
+    # Save and load again after fitting
+    state2 = opt2.save_state()
+    assert state2['is_fitted'] == True
+    assert 'target' in state2
+    assert 'model_states' in state2
+
+
+@pytest.mark.fast
+def test_load_legacy_fitted_state(X_space, Z0):
+    """Test that old saved states (without is_fitted flag) still load correctly"""
+    # Create and fit optimizer
+    opt1 = BayesianOptimizer(X_space, surrogate='GP', seed=42, verbose=0)
+    target = Target(name='Response', f_transform='Standard', aim='max')
+    opt1.fit(Z0, target=target)
+
+    # Save state
+    state = opt1.save_state()
+
+    # Simulate legacy state by removing is_fitted flag
+    if 'is_fitted' in state:
+        del state['is_fitted']
+
+    # Should still load correctly
+    opt2 = BayesianOptimizer.load_state(state)
+    assert opt2.is_fit == True  # Inferred from presence of model_states
+
+    # Predictions should match
+    y_pred = opt1.predict(opt1.X_train)
+    y_pred_2 = opt2.predict(opt2.X_train)
+    assert_allclose(y_pred.values, y_pred_2.values)
+
+
+@pytest.mark.fast
+def test_unfitted_to_fitted_cycle(X_space, Z0):
+    """Test complete cycle: create -> save -> load -> fit -> save -> load"""
+    target = Target(name='Response', f_transform='Standard', aim='max')
+
+    # 1. Create unfitted optimizer
+    opt1 = BayesianOptimizer(X_space, surrogate='GP', seed=42, verbose=0)
+
+    # 2. Save unfitted state
+    state_unfitted = opt1.save_state()
+    assert state_unfitted['is_fitted'] == False
+
+    # 3. Load unfitted state
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        opt2 = BayesianOptimizer.load_state(state_unfitted)
+    assert opt2.is_fit == False
+
+    # 4. Fit the loaded optimizer
+    opt2.fit(Z0, target=target)
+    assert opt2.is_fit == True
+
+    # 5. Save fitted state
+    state_fitted = opt2.save_state()
+    assert state_fitted['is_fitted'] == True
+
+    # 6. Load fitted state
+    opt3 = BayesianOptimizer.load_state(state_fitted)
+    assert opt3.is_fit == True
+
+    # 7. Verify predictions match
+    y_pred_2 = opt2.predict(opt2.X_train)
+    y_pred_3 = opt3.predict(opt3.X_train)
+    assert_allclose(y_pred_2.values, y_pred_3.values)
+
+
+@pytest.mark.fast
+def test_unfitted_state_round_trip(X_space):
+    """Test that unfitted optimizer state round-trips correctly"""
+    opt1 = BayesianOptimizer(X_space, surrogate='GP', seed=42, verbose=0)
+
+    # Save and load twice
+    state1 = opt1.save_state()
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        opt2 = BayesianOptimizer.load_state(state1)
+    state2 = opt2.save_state()
+
+    # States should be identical
+    assert equal_state_dicts(state1, state2)
+
+
+@pytest.mark.fast
+def test_unfitted_optimizer_operations(X_space):
+    """Test that unfitted optimizer properly raises errors for operations requiring fit"""
+    from obsidian.exceptions import UnfitError
+
+    opt = BayesianOptimizer(X_space, surrogate='GP', seed=42, verbose=0)
+
+    # Save should work
+    state = opt.save_state()
+    assert state['is_fitted'] == False
+
+    # Create a dummy DataFrame for predictions
+    designer = ExpDesigner(X_space, seed=1)
+    X_test = designer.initialize(m_initial=1, method='LHS')
+
+    # These operations should fail on unfitted optimizer
+    with pytest.raises(UnfitError):
+        opt.predict(X_test)
+
+    with pytest.raises(UnfitError):
+        opt.suggest(m_batch=1)
+
+    with pytest.raises(UnfitError):
+        opt.evaluate(X_test)
+
+
+@pytest.mark.fast
+def test_save_load_warnings(X_space, Z0, capsys):
+    """Test that warnings are issued correctly"""
+    # Test 1: Loading unfitted state issues UserWarning
+    opt_unfitted = BayesianOptimizer(X_space, surrogate='GP', seed=42, verbose=0)
+    state_unfitted = opt_unfitted.save_state()
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        BayesianOptimizer.load_state(state_unfitted)
+        assert len(w) == 1
+        assert issubclass(w[0].category, UserWarning)
+        assert "unfitted" in str(w[0].message).lower()
+
+    # Test 2: Saving unfitted optimizer prints info message (when verbose)
+    opt_verbose = BayesianOptimizer(X_space, surrogate='GP', seed=42, verbose=1)
+    opt_verbose.save_state()
+    captured = capsys.readouterr()
+    assert "unfitted" in captured.out.lower() or "configuration" in captured.out.lower()
+
+    # Test 3: Loading legacy state prints info message
+    opt_fitted = BayesianOptimizer(X_space, surrogate='GP', seed=42, verbose=0)
+    target = Target(name='Response', f_transform='Standard', aim='max')
+    opt_fitted.fit(Z0, target=target)
+    state_legacy = opt_fitted.save_state()
+    del state_legacy['is_fitted']  # Make it look like legacy
+
+    BayesianOptimizer.load_state(state_legacy)
+    captured = capsys.readouterr()
+    assert "older version" in captured.out.lower() or "missing" in captured.out.lower()
 
 
 if __name__ == '__main__':

--- a/obsidian/tests/test_parameters.py
+++ b/obsidian/tests/test_parameters.py
@@ -225,6 +225,11 @@ def test_target_validation():
     # Invalid aim
     with pytest.raises(ValueError):
         Target('Response1', aim='maximize')
+
+    # Tracking-only target is valid and keeps neutral multiplier for max aim
+    tracking_target = Target('Response1', aim='max', tracking_only=True)
+    assert tracking_target.multiplier == 1
+    assert tracking_target.tracking_only == True
     
     # Invalid f_transform
     with pytest.raises(KeyError):
@@ -264,6 +269,20 @@ def test_target_validation():
     # Corner case for Logit_Scaler
     transform_func = Logit_Scaler(standardize=False)
     transform_func.forward(test_response, fit=True)
+
+
+@pytest.mark.fast
+def test_target_save_load_tracking_only_state():
+    target = Target('Response1', f_transform='Standard', aim='min', tracking_only=True)
+    obj_dict = target.save_state()
+
+    assert obj_dict['init_attrs']['tracking_only'] == True
+    target_loaded = Target.load_state(obj_dict)
+
+    assert target_loaded.name == target.name
+    assert target_loaded.aim == target.aim
+    assert target_loaded.multiplier == -1
+    assert target_loaded.tracking_only == True
 
 
 if __name__ == '__main__':

--- a/obsidian/tests/test_plotting.py
+++ b/obsidian/tests/test_plotting.py
@@ -22,6 +22,9 @@ matplotlib.use('inline')
 
 with open(DEFAULT_MOO_PATH) as json_file:
     obj_dict = json.load(json_file)
+    # Override seeds for determinism with new RNG control
+    obj_dict['seed'] = 114514
+    obj_dict['optimizer']['opt_attrs']['seed'] = 114514
 
 campaign = Campaign.load_state(obj_dict)
 optimizer = campaign.optimizer

--- a/obsidian/tests/test_rng.py
+++ b/obsidian/tests/test_rng.py
@@ -21,7 +21,7 @@ def setup_campaign():
     """Set up a basic campaign for testing"""
     X_space = X_sp_default
     target = Target(name="Response", f_transform="Standard", aim="max")
-    simulator = Simulator(X_space, shifted_parab, eps=0.05, rng=42)
+    simulator = Simulator(X_space, shifted_parab, eps=0.05, rng=114514)
 
     return X_space, target, simulator
 

--- a/obsidian/tests/test_rng.py
+++ b/obsidian/tests/test_rng.py
@@ -74,7 +74,7 @@ def test_global_rng_operations():
     global_rng3 = obsidian.rng.get_global_rng()
     assert global_rng3.seed == 12345
     # Should be a new instance
-    assert global_rng3 is not global_rng1  
+    assert global_rng3 is not global_rng1
 
     # Test that reset changes the RNG behavior
     obsidian.rng.reset_global_rng(seed=100)
@@ -382,9 +382,9 @@ def test_optimizer_rng_save_load(setup_campaign):
     opt_state = optimizer1.save_state()
 
     # Verify RNG state is saved
-    assert 'rng_state' in opt_state
-    assert opt_state['rng_state']['seed'] == 777
-    assert opt_state['fix_random_state'] is True
+    assert "rng_state" in opt_state
+    assert opt_state["rng_state"]["seed"] == 777
+    assert opt_state["fix_random_state"] is True
 
     # Make a suggestion
     X_suggest1, _ = optimizer1.suggest(m_batch=2, acquisition=["EI"])
@@ -394,7 +394,7 @@ def test_optimizer_rng_save_load(setup_campaign):
 
     # Verify RNG attributes are restored
     assert optimizer2.seed == 777
-    assert hasattr(optimizer2, 'rng')
+    assert hasattr(optimizer2, "rng")
     assert optimizer2.rng.seed == 777
 
     # Make suggestion from loaded optimizer - should be deterministic
@@ -408,12 +408,12 @@ def test_optimizer_rng_save_load(setup_campaign):
     optimizer3.fit(Z0, target)
 
     opt_state3 = optimizer3.save_state()
-    assert opt_state3['fix_random_state'] is False
-    assert 'model_generator_state' in opt_state3  # Should save generator state
+    assert opt_state3["fix_random_state"] is False
+    assert "model_generator_state" in opt_state3  # Should save generator state
 
     # Load and verify model_generator is restored
     optimizer4 = BayesianOptimizer.load_state(opt_state3)
-    assert hasattr(optimizer4, 'model_generator')
+    assert hasattr(optimizer4, "model_generator")
     assert optimizer4.model_generator is not None
 
 

--- a/obsidian/tests/test_rng.py
+++ b/obsidian/tests/test_rng.py
@@ -1,0 +1,461 @@
+"""PyTests for RNG control mechanisms"""
+
+import pytest
+import numpy as np
+from obsidian.experiment import ExpDesigner
+import pandas as pd
+import torch
+import obsidian
+from obsidian import create_rng_manager
+from obsidian.rng import RNGManager
+from obsidian.parameters import Target
+from obsidian.campaign import Campaign
+from obsidian.optimizer import BayesianOptimizer
+from obsidian.experiment import Simulator
+from obsidian.experiment.benchmark import shifted_parab
+from obsidian.tests.param_configs import X_sp_default
+
+
+@pytest.fixture
+def setup_campaign():
+    """Set up a basic campaign for testing"""
+    X_space = X_sp_default
+    target = Target(name="Response", f_transform="Standard", aim="max")
+    simulator = Simulator(X_space, shifted_parab, eps=0.05, rng=42)
+
+    return X_space, target, simulator
+
+
+def test_create_new_rng():
+    """Test 1: Create new RNG manager with various inputs"""
+    # Create with seed
+    rng1 = create_rng_manager(42)
+    assert isinstance(rng1, RNGManager)
+    assert rng1.seed == 42
+
+    # Create without seed (random)
+    rng2 = create_rng_manager(None)
+    assert isinstance(rng2, RNGManager)
+    assert rng2.seed is not None
+
+    # Create with explicit seed
+    rng3 = create_rng_manager(123)
+    assert rng3.seed == 123
+
+    # Two RNGs with same seed should produce same random numbers
+    rng_a = create_rng_manager(999)
+    rng_b = create_rng_manager(999)
+
+    val_a = rng_a.np_rng.random(10)
+    val_b = rng_b.np_rng.random(10)
+    assert np.allclose(val_a, val_b)
+
+    # Different seeds should produce different random numbers
+    rng_c = create_rng_manager(111)
+    rng_d = create_rng_manager(222)
+
+    val_c = rng_c.np_rng.random(10)
+    val_d = rng_d.np_rng.random(10)
+    assert not np.allclose(val_c, val_d)
+
+
+def test_global_rng_operations():
+    """Test 2: Global RNG creation, retrieve, reset operations"""
+    # Test get_global_rng creates a new one if doesn't exist
+    global_rng1 = obsidian.rng.get_global_rng()
+    assert isinstance(global_rng1, RNGManager)
+
+    # Retrieving again should return the same instance
+    global_rng2 = obsidian.rng.get_global_rng()
+    assert global_rng1 is global_rng2
+
+    # Reset global RNG
+    obsidian.rng.reset_global_rng(seed=12345)
+    global_rng3 = obsidian.rng.get_global_rng()
+    assert global_rng3.seed == 12345
+    # Should be a new instance
+    assert global_rng3 is not global_rng1  
+
+    # Test that reset changes the RNG behavior
+    obsidian.rng.reset_global_rng(seed=100)
+    rng_a = obsidian.rng.get_global_rng()
+    val1 = rng_a.np_rng.random(5)
+
+    obsidian.rng.reset_global_rng(seed=100)
+    rng_b = obsidian.rng.get_global_rng()
+    val2 = rng_b.np_rng.random(5)
+
+    assert np.allclose(val1, val2)
+
+
+def test_campaign_suggest_consistency(setup_campaign):
+    """Test 3: Campaign suggest gives consistent results with deterministic acquisition (EI)"""
+    X_space, target, simulator = setup_campaign
+
+    # Create two campaigns with same seed
+    campaign1 = Campaign(X_space, target, seed=114514)
+    campaign2 = Campaign(X_space, target, seed=114514)
+
+    # Initialize and fit both campaigns with same data
+    X0 = campaign1.initialize(m_initial=5, method="LHS")
+    y0 = simulator.simulate(X0)
+    Z0 = pd.concat([X0, y0], axis=1)
+
+    campaign1.add_data(Z0)
+    campaign2.add_data(Z0)
+
+    campaign1.fit()
+    campaign2.fit()
+
+    # Suggest with EI (deterministic acquisition function)
+    X_suggest1, _ = campaign1.suggest(m_batch=3, acquisition=["EI"])
+    X_suggest2, _ = campaign2.suggest(m_batch=3, acquisition=["EI"])
+
+    # Results should be identical
+    pd.testing.assert_frame_equal(X_suggest1, X_suggest2)
+
+
+def test_manual_seed_override(setup_campaign):
+    """Test 4: Manual seed override in suggest gives different results"""
+    X_space, target, simulator = setup_campaign
+
+    # Create campaign
+    campaign = Campaign(X_space, target, seed=114514)
+
+    # Initialize and fit
+    X0 = campaign.initialize(m_initial=5, method="LHS")
+    y0 = simulator.simulate(X0)
+    Z0 = pd.concat([X0, y0], axis=1)
+    campaign.add_data(Z0)
+    campaign.fit()
+
+    # Suggest with default seed
+    X_suggest1, _ = campaign.suggest(m_batch=3, acquisition=["EI"])
+
+    # Re-fit to reset state
+    campaign.fit()
+
+    # Suggest with manual seed override
+    X_suggest2, _ = campaign.suggest(m_batch=3, acquisition=["EI"], manual_seed=999)
+
+    # Results should be different due to manual seed override
+    # (Different random restarts in optimization)
+    try:
+        pd.testing.assert_frame_equal(X_suggest1, X_suggest2)
+        # If they're equal, that's suspicious but not necessarily wrong
+        # The manual_seed affects optimization restarts, which may or may not
+        # find different optima depending on the landscape
+    except AssertionError:
+        # Expected: manual_seed changes optimization behavior
+        pass
+
+
+def test_fix_random_state(setup_campaign):
+    """Test 5: fix_random_state works as intended"""
+    X_space, target, simulator = setup_campaign
+
+    designer = ExpDesigner(X_space, seed=114514)
+
+    # Create optimizer with fix_random_state=True (default)
+    opt_fixed = BayesianOptimizer(X_space, seed=114514, fix_random_state=True)
+
+    # Create optimizer with fix_random_state=False
+    opt_not_fixed = BayesianOptimizer(X_space, seed=114514, fix_random_state=False)
+
+    # Generate data
+    X0 = designer.initialize(m_initial=5, method="LHS")
+    y0 = simulator.simulate(X0)
+    Z0 = pd.concat([X0, y0], axis=1)
+
+    # Fit both optimizers
+    opt_fixed.fit(Z0, target)
+    opt_not_fixed.fit(Z0, target)
+
+    # With fix_random_state=True, multiple fits should give identical models
+    opt_fixed_2 = BayesianOptimizer(X_space, seed=114514, fix_random_state=True)
+    opt_fixed_2.fit(Z0, target)
+
+    # Check that model parameters are identical
+    # Both should have deterministic model_generator
+    assert opt_fixed.model_generator is None
+    assert opt_fixed_2.model_generator is None
+
+    # Predictions should be identical
+    X_test = designer.initialize(m_initial=3, method="LHS")
+    pred1 = opt_fixed.predict(X_test)
+    pred2 = opt_fixed_2.predict(X_test)
+    pd.testing.assert_frame_equal(pred1, pred2)
+
+    # With fix_random_state=False, model_generator should exist
+    assert opt_not_fixed.model_generator is not None
+
+
+def test_campaign_save_load_rng_state(setup_campaign):
+    """Test 6: Campaign and optimizer save and load preserve RNG state"""
+    X_space, target, simulator = setup_campaign
+
+    # Create campaign with specific seed
+    campaign1 = Campaign(X_space, target, seed=12345)
+
+    # Initialize, add data, and fit
+    X0 = campaign1.initialize(m_initial=5, method="LHS")
+    y0 = simulator.simulate(X0)
+    Z0 = pd.concat([X0, y0], axis=1)
+    campaign1.add_data(Z0)
+    campaign1.fit()
+
+    # Make a suggestion
+    X_suggest1, _ = campaign1.suggest(m_batch=2, acquisition=["EI"])
+
+    # Save state
+    state = campaign1.save_state()
+
+    # Load into new campaign
+    campaign2 = Campaign.load_state(state)
+
+    # RNG state should be preserved
+    assert campaign2.seed == 12345
+    assert hasattr(campaign2, "rng")
+    assert campaign2.rng.seed == 12345
+
+    # Make another suggestion - should continue from saved RNG state
+    X_suggest2, _ = campaign2.suggest(m_batch=2, acquisition=["EI"])
+
+    # Both campaigns should have the same optimizer state
+    assert campaign1.optimizer.is_fit == campaign2.optimizer.is_fit
+
+    # Test optimizer save/load specifically
+    opt_state = campaign1.optimizer.save_state()
+    opt_loaded = BayesianOptimizer.load_state(opt_state)
+
+    # Check RNG state is preserved in optimizer
+    if "rng_state" in opt_state:
+        assert opt_loaded.seed == campaign1.optimizer.seed
+        assert hasattr(opt_loaded, "rng")
+
+
+def test_old_rng_control_mode(setup_campaign):
+    """Test 7: Test obsidian.USE_OLD_RNG_CONTROL works"""
+    X_space, target, simulator = setup_campaign
+
+    # Save current state
+    original_mode = obsidian.USE_OLD_RNG_CONTROL
+
+    try:
+        # Test with old RNG control (no RNGManager)
+        obsidian.USE_OLD_RNG_CONTROL = True
+
+        # Create campaign - should work without RNGManager
+        campaign_old = Campaign(X_space, target, seed=114514)
+
+        # Should not have RNGManager in old mode
+        assert not hasattr(campaign_old, "rng") or campaign_old.rng is None
+
+        # Initialize and fit should still work
+        X0 = campaign_old.initialize(m_initial=5, method="LHS")
+        y0 = simulator.simulate(X0)
+        Z0 = pd.concat([X0, y0], axis=1)
+        campaign_old.add_data(Z0)
+        campaign_old.fit()
+
+        # Suggest should still work
+        X_suggest_old, _ = campaign_old.suggest(m_batch=2)
+        assert len(X_suggest_old) == 2
+
+        # Test with new RNG control
+        obsidian.USE_OLD_RNG_CONTROL = False
+
+        campaign_new = Campaign(X_space, target, seed=114514)
+
+        # Should have RNGManager in new mode
+        assert hasattr(campaign_new, "rng")
+        assert isinstance(campaign_new.rng, RNGManager)
+
+        # Initialize and fit
+        X0_new = campaign_new.initialize(m_initial=5, method="LHS")
+        y0_new = simulator.simulate(X0_new)
+        Z0_new = pd.concat([X0_new, y0_new], axis=1)
+        campaign_new.add_data(Z0_new)
+        campaign_new.fit()
+
+        # Suggest should work
+        X_suggest_new, _ = campaign_new.suggest(m_batch=2)
+        assert len(X_suggest_new) == 2
+
+    finally:
+        # Restore original mode
+        obsidian.USE_OLD_RNG_CONTROL = original_mode
+
+
+def test_rng_state_save_load():
+    """Test RNGManager state save/load"""
+    # Create RNG with seed
+    rng1 = create_rng_manager(777)
+
+    # Generate some random numbers to advance state
+    rng1.np_rng.random(10)
+    torch.rand(5, generator=rng1.torch_rng)
+
+    # Save state
+    state = rng1.save_state()
+
+    # Generate more numbers
+    val1_np = rng1.np_rng.random(5)
+    val1_torch = torch.rand(3, generator=rng1.torch_rng)
+
+    # Load state into new RNG
+    rng2 = RNGManager.load_state(state)
+
+    # Should produce same numbers as rng1 did after state was saved
+    val2_np = rng2.np_rng.random(5)
+    val2_torch = torch.rand(3, generator=rng2.torch_rng)
+
+    assert np.allclose(val1_np, val2_np)
+    assert torch.allclose(val1_torch, val2_torch)
+
+
+def test_simulator_rng_consistency():
+    """Test that Simulator uses RNG correctly for reproducible noise"""
+    X_space = X_sp_default
+
+    # Create two simulators with same RNG seed
+    sim1 = Simulator(X_space, shifted_parab, eps=0.1, rng=555)
+    sim2 = Simulator(X_space, shifted_parab, eps=0.1, rng=555)
+
+    # Generate same test points
+    X_test = pd.DataFrame(
+        {
+            "Parameter 1": [5.0, 7.5, 2.5],
+            "Parameter 2": [-10.0, -5.0, -15.0],
+            "Parameter 3": [5.0, 5.0, 5.0],
+            "Parameter 7": ["A", "B", "C"],
+        }
+    )
+
+    # Simulate - should get identical results (including noise)
+    y1 = sim1.simulate(X_test)
+    y2 = sim2.simulate(X_test)
+
+    pd.testing.assert_frame_equal(y1, y2)
+
+    # Different seeds should give different noise
+    sim3 = Simulator(X_space, shifted_parab, eps=0.1, rng=999)
+    y3 = sim3.simulate(X_test)
+
+    # Results should differ due to different noise
+    with pytest.raises(AssertionError):
+        pd.testing.assert_frame_equal(y1, y3)
+
+
+def test_shared_rng_flag(setup_campaign):
+    """Test sharing RNG between campaign and optimizer"""
+    X_space, target, _ = setup_campaign
+
+    # Create shared RNG
+    shared_rng = create_rng_manager(42)
+
+    # Create optimizer with shared RNG
+    optimizer = BayesianOptimizer(X_space, rng=shared_rng)
+
+    # Creating campaign with shared RNG should produce warning
+    campaign = Campaign(X_space, target, optimizer=optimizer, rng=shared_rng)
+    assert campaign.rng is optimizer.rng
+    assert campaign._owns_rng is False
+
+
+def test_optimizer_rng_save_load(setup_campaign):
+    """Test that optimizer RNG state is properly saved and restored"""
+    X_space, target, simulator = setup_campaign
+
+    # Create optimizer with specific seed
+    optimizer1 = BayesianOptimizer(X_space, seed=777, fix_random_state=True)
+
+    # Generate and fit data
+    designer = ExpDesigner(X_space, seed=777)
+    X0 = designer.initialize(m_initial=5, method="LHS")
+    y0 = simulator.simulate(X0)
+    Z0 = pd.concat([X0, y0], axis=1)
+
+    optimizer1.fit(Z0, target)
+
+    # Save optimizer state
+    opt_state = optimizer1.save_state()
+
+    # Verify RNG state is saved
+    assert 'rng_state' in opt_state
+    assert opt_state['rng_state']['seed'] == 777
+    assert opt_state['fix_random_state'] is True
+
+    # Make a suggestion
+    X_suggest1, _ = optimizer1.suggest(m_batch=2, acquisition=["EI"])
+
+    # Load optimizer from saved state
+    optimizer2 = BayesianOptimizer.load_state(opt_state)
+
+    # Verify RNG attributes are restored
+    assert optimizer2.seed == 777
+    assert hasattr(optimizer2, 'rng')
+    assert optimizer2.rng.seed == 777
+
+    # Make suggestion from loaded optimizer - should be deterministic
+    X_suggest2, _ = optimizer2.suggest(m_batch=2, acquisition=["EI"])
+
+    # With fix_random_state=True, both should give same results
+    pd.testing.assert_frame_equal(X_suggest1, X_suggest2)
+
+    # Test with fix_random_state=False
+    optimizer3 = BayesianOptimizer(X_space, seed=888, fix_random_state=False)
+    optimizer3.fit(Z0, target)
+
+    opt_state3 = optimizer3.save_state()
+    assert opt_state3['fix_random_state'] is False
+    assert 'model_generator_state' in opt_state3  # Should save generator state
+
+    # Load and verify model_generator is restored
+    optimizer4 = BayesianOptimizer.load_state(opt_state3)
+    assert hasattr(optimizer4, 'model_generator')
+    assert optimizer4.model_generator is not None
+
+
+def test_rng_reproducibility_full_workflow(setup_campaign):
+    """Integration test: Full workflow should be reproducible with same seed"""
+    X_space, target, _ = setup_campaign
+
+    def run_campaign(seed):
+        # Create simulator with fixed seed
+        sim = Simulator(X_space, shifted_parab, eps=0.05, rng=seed)
+
+        # Create campaign
+        campaign = Campaign(X_space, target, seed=seed)
+
+        # Initialize
+        X0 = campaign.initialize(m_initial=5, method="LHS")
+        y0 = sim.simulate(X0)
+        Z0 = pd.concat([X0, y0], axis=1)
+
+        # Add data and fit
+        campaign.add_data(Z0)
+        campaign.fit()
+
+        # Suggest
+        X_suggest, eval_suggest = campaign.suggest(m_batch=3, acquisition=["EI"])
+
+        return X0, y0, X_suggest, eval_suggest
+
+    # Run twice with same seed
+    X0_a, y0_a, X_suggest_a, eval_suggest_a = run_campaign(12345)
+    X0_b, y0_b, X_suggest_b, eval_suggest_b = run_campaign(12345)
+
+    # Everything should be identical
+    pd.testing.assert_frame_equal(X0_a, X0_b)
+    pd.testing.assert_frame_equal(y0_a, y0_b)
+    pd.testing.assert_frame_equal(X_suggest_a, X_suggest_b)
+    # eval_suggest may have small numerical differences in predictions
+    # so we test with tolerance
+    for col in eval_suggest_a.columns:
+        if eval_suggest_a[col].dtype in [np.float64, np.float32]:
+            assert np.allclose(eval_suggest_a[col].values, eval_suggest_b[col].values, rtol=1e-5, atol=1e-8)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/obsidian/tests/utils.py
+++ b/obsidian/tests/utils.py
@@ -51,6 +51,7 @@ def equal_state_dicts(e1: dict | str | float | int,
     return True
 
 
+#TODO: Remove it in a future PR. This is almost entirely redundant given numpy.testing.assert_allclose and numpy.isclose and with bugs
 def approx_equal(x1: ArrayLike | float | int,
                  x2: ArrayLike | float | int,
                  tol: float = 1e-6):

--- a/obsidian/utils.py
+++ b/obsidian/utils.py
@@ -3,6 +3,7 @@
 from obsidian.parameters import Target
 from torch import Tensor
 import torch
+from enum import Enum
 
 
 def unscale_samples(samples: Tensor,
@@ -76,3 +77,40 @@ def dict_to_tensordict(dict: dict[float | int | str]) -> dict[Tensor]:
         else:
             state_dict[param] = torch.tensor(dict[param])
     return state_dict
+
+
+class TaskType(Enum):
+    """
+    Task types for specifying an optimization or characterization task.
+    """
+    OPTIMIZATION = "optimization"
+    CHARACTERIZATION = "characterization"
+
+    @classmethod
+    def allowed_tasks(cls) -> str:
+        return ", ".join(f"{t.value!r} (TaskType.{t.name})" for t in cls)
+
+    @classmethod
+    def from_value(cls, task: "TaskType | str") -> "TaskType":
+        """
+        Converts a string representation of a task type to a TaskType enum.
+
+        Args:
+            task_str (str): The string representation of the task type.
+
+        Returns:
+            TaskType: The corresponding TaskType enum.
+
+        Raises:
+            ValueError: If the task_str does not match any TaskType.
+        """
+        if isinstance(task, str):
+            try:
+                return TaskType[task.upper()]
+            except KeyError:
+                pass
+        elif isinstance(task, cls):
+            return task
+        else:
+            raise TypeError(f"Expected task to be of type str or TaskType, got {type(task)}")
+        raise ValueError(f"Unknown task type: {task!r}. Choose from {TaskType.allowed_tasks()}")

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,5 @@ filterwarnings =
     ignore::linear_operator.utils.warnings.NumericalWarning
     ignore::gpytorch.utils.warnings.GPInputWarning
     ignore::UserWarning
+    ignore::DeprecationWarning
+    ignore::FutureWarning


### PR DESCRIPTION
Refactors acquisition function management in the Bayesian optimizer to use a structured registry pattern, adds support for tracking-only targets, and includes several bug fixes.

This PR is built upon #81 and some other smaller fixes.

## Key Changes

### Acquisition Function Refactor

- Introduced AcquisitionConfig class for structured configuration of acquisition functions (hyperparameters, parsing logic)
- Introduced AcquisitionRegistry as a centralized registry for internal and external acquisition functions, replacing ad-hoc dictionary lookups
- Added ParserContext type and TaskType enum to formalize hyperparameter parsing and optimization/characterization task types
- Refactored suggest() and evaluate() in bayesian.py to reduce code duplication, using registry-based acquisition instantiation and new helper methods (_build_parser_context, _setup_model_and_objective, _setup_constraints)
- Added support for registering external acquisition functions
- Maintained backward compatibility by exporting necessary properties from the registry

### Tracking-Only Targets

- Users can now specify targets as "tracking-only" — these are recorded but not optimized by default, and can be explicitly included in optimization when needed
- Simplifies setting up campaigns with mixed target types
- Includes save/load support and tests for this feature

### Optimizer State

- Added support for saving/loading the state of unfitted optimizers
- Maintained backward compatibility with existing saved states